### PR TITLE
Closes #2: Add support for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,29 @@ yarn add appstraction
 # or `npm i appstraction`
 ```
 
-For full capabilities, you also need to install [frida-tools](https://frida.re/docs/installation/) and [objection](https://github.com/sensepost/objection).
-You can get the paths to the binaries after installation using `whereis frida-ps`.
+Additionally, you will need to [prepare the target device/emulator](#device-preparation) and install a few dependencies on the host machine.
 
-For Android, you also need the [Android command line tools](https://developer.android.com/studio/command-line/) installed (the best way to do this is to install [Android Studio](https://developer.android.com/studio)) and included in the `PATH` of the shell in which you are running appstraction, e.g. by including something like this in you `.zshrc`/`.bashrc`:
+### Host dependencies for Android
+
+For Android, you need the [Android command line tools](https://developer.android.com/studio/command-line/) (can also be installed through [Android Studio](https://developer.android.com/studio)). Note that these need to be included in your `PATH`, e.g. by including something like this in your `.zshrc`/`.bashrc`:
 
 ```sh
 # Android SDK
 export ANDROID_HOME="$HOME/Android/Sdk"
 export PATH="$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/33.0.0:$ANDROID_HOME/cmdline-tools/latest/bin/:$ANDROID_HOME/emulator"
 ```
+
+For the `frida` capability, you need to install [`frida-tools`](https://frida.re/docs/installation/).
+
+For the `certificate-pinning-bypass` capability, you need to install [`objection`](https://github.com/sensepost/objection) in addition to `frida-tools`.
+
+### Host dependencies for iOS
+
+For iOS, you need [`libimobiledevice`](https://libimobiledevice.org/). The distribution packages are fine, you don't need to build from source.
+
+For the `frida` capability, you need to install [`frida-tools`](https://frida.re/docs/installation/).
+
+For the `ssh` capability, you need to install [`sshpass`](https://sourceforge.net/projects/sshpass).
 
 ## Supported targets
 
@@ -32,6 +45,7 @@ Appstraction supports the following targets. Note that it will likely also work 
 | --- | --- | --- |
 | Android | `device` | 13 (API level 33) |
 | Android | `emulator` | 11 (API level 30), 13 (API level 33) |
+| iOS | `device` | 15.6.1, 16.0 |
 
 ## Device preparation
 
@@ -105,6 +119,21 @@ After you have set up the emulator to your liking, you should create a snapshot 
 adb emu avd snapshot save "<snapshot name>" # Specify this name in `targetOptions.snapshotName`.
 ```
 
+### Physical iOS device
+
+Installing and uninstalling apps and querying the metadata of an IPA file work without any preparation on a physical iOS device.
+
+For everything else, the iOS device needs to be jailbroken. For iOS 15 and 16, we have tested [palera1n](https://github.com/palera1n/palera1n). For iOS 14, we have previously successfully used [checkra1n](https://checkra.in/) for other projects, but we have not tested appstraction on iOS 14 (as we don't have a device running iOS 14).
+
+Depending on the capabilities and features you want to use, you need to install the following packages from Cydia/Sileo:
+
+* [OpenSSH](sileo://package/openssh) (for the `ssh` capability)
+* [SQLite 3.x](sileo://package/sqlite3) (if you want to set app permissions)
+* [Frida](sileo://package/re.frida.server) (for the `frida` capability), you will need to [add the Frida repository to Cydia/Sileo](https://frida.re/docs/ios/#with-jailbreak): `https://build.frida.re`
+* [Open](http://cydia.saurik.com/package/com.conradkramer.open/) (if you want to launch apps without the `frida` capability), you will need to add a legacy Cydia repository if you are using Sileo: `https://apt.thebigboss.org/repofiles/cydia/`
+
+You may need to respring after installing the packages.
+
 ## API reference
 
 A full API reference can be found in the [`docs` folder](/docs/README.md).
@@ -156,7 +185,7 @@ Other functions do need capabilities, though, which you would pass to the `capab
 })();
 ```
 
-For more examples, also look at the [`examples`](examples) folder.
+For more examples, take a look at the [`examples`](examples) folder.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:232](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L232)
+[index.ts:240](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L240)
 
 ___
 
@@ -54,7 +54,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:238](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L238)
+[index.ts:246](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L246)
 
 ___
 
@@ -76,7 +76,8 @@ Functions that are available for the platforms.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `clearStuckModals` | () => `Promise`<`void`\> | Clear any potential stuck modals by pressing the back button followed by the home button. Requires the `ssh` capability on iOS. |
-| `ensureDevice` | () => `Promise`<`void`\> | Assert that the selected device is connected and ready to be used. |
+| `ensureDevice` | () => `Promise`<`void`\> | Assert that the selected device is connected and ready to be used with the selected capabilities. |
+| `getAppId` | (`appPath`: `string`) => `Promise`<`string` \| `undefined`\> | Get the app/bundle ID of the app at the given path. |
 | `getAppVersion` | (`appPath`: `string`) => `Promise`<`string` \| `undefined`\> | Get the version of the app at the given path. |
 | `getDeviceAttribute` | <Attribute\>(`attribute`: `Attribute`, ...`options`: `Attribute` extends keyof [`GetDeviceAttributeOptions`](README.md#getdeviceattributeoptions) ? [options: GetDeviceAttributeOptions[Attribute]] : [options?: undefined]) => `Promise`<`string`\> | Get the value of the given attribute of the device. Requires the `frida` capability on iOS. |
 | `getForegroundAppId` | () => `Promise`<`string` \| `undefined`\> | Get the app ID of the running app that is currently in the foreground. Requires the `frida` capability on iOS. |
@@ -120,7 +121,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:146](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L146)
+[index.ts:154](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L154)
 
 ___
 
@@ -150,7 +151,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:166](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L166)
+[index.ts:174](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L174)
 
 ___
 
@@ -168,7 +169,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:225](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L225)
+[index.ts:233](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L233)
 
 ___
 
@@ -230,4 +231,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:253](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L253)
+[index.ts:261](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L261)

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:240](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L240)
+[index.ts:242](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L242)
 
 ___
 
@@ -54,7 +54,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:246](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L246)
+[index.ts:248](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L248)
 
 ___
 
@@ -75,7 +75,7 @@ Functions that are available for the platforms.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `clearStuckModals` | () => `Promise`<`void`\> | Clear any potential stuck modals by pressing the back button followed by the home button. Requires the `ssh` capability on iOS. |
+| `clearStuckModals` | `Platform` extends ``"android"`` ? () => `Promise`<`void`\> : `never` | Clear any potential stuck modals by pressing the back button followed by the home button. This is currently broken on iOS (see https://github.com/tweaselORG/appstraction/issues/12). Requires the `ssh` capability on iOS. |
 | `ensureDevice` | () => `Promise`<`void`\> | Assert that the selected device is connected and ready to be used with the selected capabilities. |
 | `getAppId` | (`appPath`: `string`) => `Promise`<`string` \| `undefined`\> | Get the app/bundle ID of the app at the given path. |
 | `getAppVersion` | (`appPath`: `string`) => `Promise`<`string` \| `undefined`\> | Get the version of the app at the given path. |
@@ -87,7 +87,7 @@ Functions that are available for the platforms.
 | `resetDevice` | `Platform` extends ``"android"`` ? `RunTarget` extends ``"emulator"`` ? () => `Promise`<`void`\> : `never` : `never` | Reset the device to the snapshot specified in the `targetOptions.snapshotName` (only available for emulators). |
 | `setAppPermissions` | (`appId`: `string`) => `Promise`<`void`\> | Set the permissions for the app with the given app ID. This includes dangerous permissions on Android. Requires the `ssh` and `frida` capabilities on iOS. **`Todo`** Allow specifying which permissions to grant. |
 | `setClipboard` | (`text`: `string`) => `Promise`<`void`\> | Set the clipboard to the given text. Requires the `frida` capability on Android and iOS. |
-| `startApp` | (`appId`: `string`) => `Promise`<`void`\> | Start the app with the given app ID. Doesn't wait for the app to be ready. Also enables the certificate pinning bypass if enabled. Requires the `ssh` capability on iOS. On Android, this will start the app with or without a certificate pinning bypass depending on the `certificate-pinning-bypass` capability. |
+| `startApp` | (`appId`: `string`) => `Promise`<`void`\> | Start the app with the given app ID. Doesn't wait for the app to be ready. Also enables the certificate pinning bypass if enabled. Requires the `frida` or `ssh` capability on iOS. On Android, this will start the app with or without a certificate pinning bypass depending on the `certificate-pinning-bypass` capability. |
 | `uninstallApp` | (`appId`: `string`) => `Promise`<`void`\> | Uninstall the app with the given app ID. Will not fail if the app is not installed. This also removes any data stored by the app. |
 
 #### Defined in
@@ -121,7 +121,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:154](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L154)
+[index.ts:156](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L156)
 
 ___
 
@@ -151,7 +151,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:174](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L174)
+[index.ts:176](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L176)
 
 ___
 
@@ -169,7 +169,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:233](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L233)
+[index.ts:235](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L235)
 
 ___
 
@@ -231,4 +231,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:261](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L261)
+[index.ts:263](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L263)

--- a/examples/android-device.ts
+++ b/examples/android-device.ts
@@ -24,8 +24,9 @@ import { pause, platformApi } from '../src/index';
 
     await android.setClipboard('I copied this.');
 
+    const id = await android.getAppId(`${appPath}/${appId}/${appId}.apk`);
     const version = await android.getAppVersion(`${appPath}/${appId}/${appId}.apk`);
-    console.log('App version:', version);
+    console.log('App:', id, '@', version);
 
     await android.installApp(`${appPath}/${appId}/*.apk`);
     await android.setAppPermissions(appId);

--- a/examples/android-emulator.ts
+++ b/examples/android-emulator.ts
@@ -26,8 +26,9 @@ import { pause, platformApi } from '../src/index';
 
     await android.setClipboard('I copied this.');
 
+    const id = await android.getAppId(`${appPath}/${appId}/${appId}.apk`);
     const version = await android.getAppVersion(`${appPath}/${appId}/${appId}.apk`);
-    console.log('App version:', version);
+    console.log('App:', id, '@', version);
 
     await android.installApp(`${appPath}/${appId}/*.apk`);
     await android.setAppPermissions(appId);

--- a/examples/ios-device.ts
+++ b/examples/ios-device.ts
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+import { homedir } from 'os';
+import { join } from 'path';
+import { pause, platformApi } from '../src/index';
+
+// You can pass the following command line arguments:
+// `npx tsm examples/ios-device.ts <ip> <app path>`
+
+(async () => {
+    const ios = platformApi({
+        platform: 'ios',
+        runTarget: 'device',
+        capabilities: ['frida', 'ssh'],
+        targetOptions: {
+            fridaPsPath: join(homedir(), '.local/bin/frida-ps'),
+            ip: process.argv[2],
+        },
+    });
+
+    const appPath = process.argv[3] || '/path/to/app-files';
+
+    await ios.ensureDevice();
+
+    await ios.setClipboard('I copied this.');
+
+    const appId = await ios.getAppId(appPath);
+    const version = await ios.getAppVersion(appPath);
+    console.log('App:', appId, '@', version);
+    if (!appId) throw new Error('Invalid app.');
+
+    await ios.installApp(appPath);
+    await ios.setAppPermissions(appId);
+    await ios.startApp(appId);
+
+    // Give the app some time to start.
+    await pause(5000);
+
+    const prefs = await ios.getPrefs(appId);
+    console.log(prefs);
+
+    const idfv = await ios.getDeviceAttribute('idfv', { appId });
+    console.log('IDFV:', idfv);
+
+    // `clearStuckModals()` is currently broken on iOS (see https://github.com/tweaselORG/appstraction/issues/12).
+    // await ios.clearStuckModals();
+    await ios.uninstallApp(appId);
+})();
+/* eslint-enable no-console */

--- a/src/android.ts
+++ b/src/android.ts
@@ -167,8 +167,12 @@ export const androidApi = <RunTarget extends SupportedRunTarget<'android'>>(
         throw new Error('Setting clipboard failed.');
     },
 
+    // These sometimes fail with `AndroidManifest.xml:42: error: ERROR getting 'android:icon' attribute: attribute value
+    // reference does not exist` but still have the correct version in the output.
+    getAppId: async (apkPath) =>
+        (await execa('aapt', ['dump', 'badging', apkPath], { reject: false })).stdout.match(
+            /package: name='(.+?)'/
+        )?.[1],
     getAppVersion: async (apkPath) =>
-        // These sometimes fail with `AndroidManifest.xml:42: error: ERROR getting 'android:icon' attribute: attribute value
-        // reference does not exist` but still have the correct version in the output.
         (await execa('aapt', ['dump', 'badging', apkPath], { reject: false })).stdout.match(/versionName='(.+?)'/)?.[1],
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export type SupportedRunTarget<Platform extends SupportedPlatform> = Platform ex
 
 /** Functions that are available for the platforms. */
 export type PlatformApi<Platform extends SupportedPlatform, RunTarget extends SupportedRunTarget<Platform>> = {
-    /** Assert that the selected device is connected and ready to be used. */
+    /** Assert that the selected device is connected and ready to be used with the selected capabilities. */
     ensureDevice: () => Promise<void>;
     /** Reset the device to the snapshot specified in the `targetOptions.snapshotName` (only available for emulators). */
     resetDevice: Platform extends 'android' ? (RunTarget extends 'emulator' ? () => Promise<void> : never) : never;
@@ -120,6 +120,14 @@ export type PlatformApi<Platform extends SupportedPlatform, RunTarget extends Su
      */
     setClipboard: (text: string) => Promise<void>;
 
+    /**
+     * Get the app/bundle ID of the app at the given path.
+     *
+     * @param appPath Path to the app file (`.ipa` on iOS, `.apk` on Android) to get the app ID of.
+     *
+     * @returns The app ID, or `undefined` if the file doesn't exist or is not a valid app for the platform.
+     */
+    getAppId: (appPath: string) => Promise<string | undefined>;
     /**
      * Get the version of the app at the given path.
      *

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,11 @@ export type PlatformApi<Platform extends SupportedPlatform, RunTarget extends Su
     /**
      * Clear any potential stuck modals by pressing the back button followed by the home button.
      *
+     * This is currently broken on iOS (see https://github.com/tweaselORG/appstraction/issues/12).
+     *
      * Requires the `ssh` capability on iOS.
      */
-    clearStuckModals: () => Promise<void>;
+    clearStuckModals: Platform extends 'android' ? () => Promise<void> : never;
 
     /**
      * Install the app at the given path.
@@ -54,8 +56,8 @@ export type PlatformApi<Platform extends SupportedPlatform, RunTarget extends Su
      * Start the app with the given app ID. Doesn't wait for the app to be ready. Also enables the certificate pinning
      * bypass if enabled.
      *
-     * Requires the `ssh` capability on iOS. On Android, this will start the app with or without a certificate pinning
-     * bypass depending on the `certificate-pinning-bypass` capability.
+     * Requires the `frida` or `ssh` capability on iOS. On Android, this will start the app with or without a
+     * certificate pinning bypass depending on the `certificate-pinning-bypass` capability.
      *
      * @param appId The app ID of the app to start.
      */

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -1,7 +1,7 @@
 import { execa } from 'execa';
 import frida from 'frida';
 import type { PlatformApi, PlatformApiOptions, SupportedCapability, SupportedRunTarget } from '.';
-import { asyncNop, asyncUnimplemented, getObjFromFridaScript, ipaInfo, isRecord } from './util';
+import { asyncUnimplemented, getObjFromFridaScript, ipaInfo, isRecord } from './util';
 
 const fridaScripts = {
     getPrefs: `// Taken from: https://codeshare.frida.re/@dki/ios-app-info/
@@ -24,6 +24,8 @@ send({ name: "get_obj_from_frida_script", payload: dictFromNSDictionary(prefs) }
 send({ name: "get_obj_from_frida_script", payload: idfv });`,
     grantLocationPermission: (appId: string) =>
         `ObjC.classes.CLLocationManager.setAuthorizationStatusByType_forBundleIdentifier_(4, "${appId}");`,
+    startApp: (appId: string) =>
+        `ObjC.classes.LSApplicationWorkspace.defaultWorkspace().openApplicationWithBundleID_("${appId}");`,
 } as const;
 
 export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
@@ -34,19 +36,36 @@ export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
     },
 
     resetDevice: asyncUnimplemented('resetDevice') as never,
-    // TODO: Assert that we actually have a device here.
-    ensureDevice: asyncNop,
-    clearStuckModals: async () => {
-        if (!options.capabilities.includes('ssh')) throw new Error('SSH is required for clearing stuck modals.');
+    ensureDevice: async () => {
+        if ((await execa('ideviceinfo', ['-k', 'DeviceName'], { reject: false })).exitCode !== 0)
+            throw new Error('You need to connect your device and trust this computer.');
 
-        await execa('sshpass', [
-            '-p',
-            options.targetOptions.rootPw || 'alpine',
-            'ssh',
-            `root@${options.targetOptions.ip}`,
-            `activator send libactivator.system.clear-switcher; activator send libactivator.system.homebutton`,
-        ]);
+        if (options.capabilities.includes('frida')) {
+            const session = await frida
+                .getUsbDevice()
+                .then((f) => f.attach('SpringBoard'))
+                .catch((err) => {
+                    throw new Error('Cannot connect using Frida.', { cause: err });
+                });
+            await session.detach();
+        }
+
+        if (options.capabilities.includes('ssh')) {
+            try {
+                const { stdout } = await execa('sshpass', [
+                    '-p',
+                    options.targetOptions.rootPw || 'alpine',
+                    'ssh',
+                    `root@${options.targetOptions.ip}`,
+                    `uname`,
+                ]);
+                if (stdout !== 'Darwin') throw new Error('Wrong uname output.');
+            } catch (err) {
+                throw new Error('Cannot connect using SSH.', { cause: err });
+            }
+        }
     },
+    clearStuckModals: asyncUnimplemented('clearStuckModals') as never,
 
     // We're using `libimobiledevice` instead of `cfgutil` because the latter doesn't wait for the app to be fully
     // installed before exiting.
@@ -65,27 +84,18 @@ export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
         const permissionsToDeny = ['kTCCServiceCamera', 'kTCCServiceMicrophone', 'kTCCServiceUserTracking'];
 
         // value === 0 for not granted, value === 2 for granted
-        const setPermission = async (permission: string, value: 0 | 2) => {
-            const timestamp = Math.floor(Date.now() / 1000);
-            await execa('sshpass', [
+        const setPermission = (permission: string, value: 0 | 2) =>
+            execa('sshpass', [
                 '-p',
                 options.targetOptions.rootPw || 'alpine',
                 'ssh',
                 `root@${options.targetOptions.ip}`,
                 'sqlite3',
                 '/private/var/mobile/Library/TCC/TCC.db',
-                `'INSERT OR REPLACE INTO access VALUES("${permission}", "${appId}", 0, ${value}, 2, 1, NULL, NULL, 0, "UNUSED", NULL, 0, ${timestamp});'`,
+                `'INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version) VALUES("${permission}", "${appId}", 0, ${value}, 2, 1);'`,
             ]);
-        };
         const grantLocationPermission = async () => {
-            await execa('sshpass', [
-                '-p',
-                options.targetOptions.rootPw || 'alpine',
-                'ssh',
-                `root@${options.targetOptions.ip}`,
-                'open com.apple.Preferences',
-            ]);
-            const session = await frida.getUsbDevice().then((f) => f.attach('Settings'));
+            const session = await frida.getUsbDevice().then((f) => f.attach('SpringBoard'));
             const script = await session.createScript(fridaScripts.grantLocationPermission(appId));
             await script.load();
             await session.detach();
@@ -96,15 +106,22 @@ export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
         await grantLocationPermission();
     },
     startApp: async (appId) => {
-        if (!options.capabilities.includes('ssh')) throw new Error('SSH is required for starting apps.');
-
-        await execa('sshpass', [
-            '-p',
-            options.targetOptions.rootPw || 'alpine',
-            'ssh',
-            `root@${options.targetOptions.ip}`,
-            `open ${appId}`,
-        ]);
+        if (options.capabilities.includes('frida')) {
+            const session = await frida.getUsbDevice().then((f) => f.attach('SpringBoard'));
+            const script = await session.createScript(fridaScripts.startApp(appId));
+            await script.load();
+            await session.detach();
+        } else if (options.capabilities.includes('ssh')) {
+            execa('sshpass', [
+                '-p',
+                options.targetOptions.rootPw || 'alpine',
+                'ssh',
+                `root@${options.targetOptions.ip}`,
+                `open ${appId}`,
+            ]);
+        } else {
+            throw new Error('Frida or SSH (with the open package installed) is required for starting apps.');
+        }
     },
 
     getForegroundAppId: async () => {
@@ -145,7 +162,7 @@ export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
         switch (attribute) {
             case 'idfv': {
                 const pid = await this.getPidForAppId(opts.appId);
-                const idfv = getObjFromFridaScript(pid, fridaScripts.getIdfv);
+                const idfv = await getObjFromFridaScript(pid, fridaScripts.getIdfv);
                 if (typeof idfv === 'string') return idfv;
                 throw new Error('Failed to get IDFV.');
             }

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -162,5 +162,6 @@ export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
         await session.detach();
     },
 
+    getAppId: async (ipaPath) => (await ipaInfo(ipaPath)).info['CFBundleIdentifier'] as string | undefined,
     getAppVersion: async (ipaPath) => (await ipaInfo(ipaPath)).info['CFBundleShortVersionString'] as string | undefined,
 });


### PR DESCRIPTION
This required a few changes, most notably:

* `clearStuckModals()` is currently disabled (https://github.com/tweaselORG/appstraction/issues/12).
* `startApp()` can now either use a Frida script or the `open` package.
* `ensureDevice()` now actually checks that we are connected to the device and that the dependencies for the capabilities are set up correctly.

This PR also adds a new `getAppId()` function that was necessary for the iOS example file.