### PR TITLE
iOS: Support for managing proxies and certificate authorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,28 +82,9 @@ To use appstraction with a physical Android device, you need to enable USB debug
 
 Some functions require the device to be rooted. The steps to do this vary depending on the device. We recommend using [Magisk](https://topjohnwu.github.io/Magisk/). After you have rooted the device, you need to enable rooted debugging via Settings -> System -> Developer options -> Rooted debugging.
 
-Some functions require Frida. If you want to use them, you need to [set up Frida](https://frida.re/docs/android/) on the emulator (make sure that the version you're installing matches the version of the Frida tools you're using):
-
-```sh
-adb root
-
-# Find out the architecture of the device.
-adb shell getprop ro.product.cpu.abi
-# Download the correct frida-server, e.g. for ARM64:
-wget https://github.com/frida/frida/releases/download/16.0.8/frida-server-16.0.8-android-arm64.xz
-unxz frida-server-16.0.8-android-arm64.xz
-
-adb push frida-server-16.0.8-android-arm64 /data/local/tmp/frida-server
-adb shell chmod 777 /data/local/tmp/frida-server
-
-# Test that Frida is working. You don't need to start Frida manually in later runs, appstraction will do that for you.
-adb shell "/data/local/tmp/frida-server"
-frida-ps -U | grep frida # should have `frida-server`
-```
-
 ### Android emulator
 
-Some of the functions in appstraction work without any special preparation in an emulator. You can create the emulator using Android Studio or the command line tools, e.g. like this to create an emulator with Google APIs running Android 13 (API level 33)—we recommend using x86_64 as the architecture (you can still [run ARM apps if you use Android 11 or newer](https://android-developers.googleblog.com/2020/03/run-arm-apps-on-android-emulator.html)):
+Appstraction doesn't require any special preparation in an emulator. You can create the emulator using Android Studio or the command line tools, e.g. like this to create an emulator with Google APIs running Android 13 (API level 33)—we recommend using x86_64 as the architecture (you can still [run ARM apps if you use Android 11 or newer](https://android-developers.googleblog.com/2020/03/run-arm-apps-on-android-emulator.html)):
 
 ```sh
 # Fetch the system image.
@@ -119,23 +100,6 @@ On subsequent runs, don't include the `-partition-size 8192 -wipe-data` flags, i
 
 ```sh
 emulator -avd "<emulator name>"
-```
-
-Some functions require Frida. If you want to use them, you need to [set up Frida](https://frida.re/docs/android/) on the emulator (make sure that the version you're installing matches the version of the Frida tools you're using):
-
-```sh
-adb root
-
-adb shell getprop ro.product.cpu.abi # should be x86_64
-wget https://github.com/frida/frida/releases/download/16.0.8/frida-server-16.0.8-android-x86_64.xz 
-unxz frida-server-16.0.8-android-x86_64.xz
-
-adb push frida-server-16.0.8-android-x86_64 /data/local/tmp/frida-server
-adb shell chmod 777 /data/local/tmp/frida-server
-
-# Test that Frida is working. You don't need to start Frida manually in later runs, appstraction will do that for you.
-adb shell "/data/local/tmp/frida-server"
-frida-ps -U | grep frida # should have `frida-server`
 ```
 
 After you have set up the emulator to your liking, you should create a snapshot to later be able to reset the emulator to this state:
@@ -188,7 +152,7 @@ Note how the first function we call after constructing the API object is `ensure
 
 This example didn't need any capabilities. Resetting the emulator and installing apps can both be done in any emulator, without the need for any special preparation.
 
-Other functions do need capabilities, though, which you would pass to the `capabilities` array in the options. For example, reading the `SharedPreferences` requires the `frida` capability (and you need to set up Frida as described above). And for starting an app, you can optionally pass the `certificate-pinning-bypass`, which will use objection to try and bypass any certificate pinning the app may use.
+Other functions do need capabilities, though, which you would pass to the `capabilities` array in the options. For example, reading the `SharedPreferences` requires the `frida` capability. And for starting an app, you can optionally pass the `certificate-pinning-bypass`, which will use objection to try and bypass any certificate pinning the app may use.
 
 ```ts
 (async () => {

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Depending on the capabilities and features you want to use, you need to install 
 * [SQLite 3.x](sileo://package/sqlite3) (if you want to set app permissions)
 * [Frida](sileo://package/re.frida.server) (for the `frida` capability), you will need to [add the Frida repository to Cydia/Sileo](https://frida.re/docs/ios/#with-jailbreak): `https://build.frida.re`
 * [Open](http://cydia.saurik.com/package/com.conradkramer.open/) (if you want to launch apps without the `frida` capability), you will need to add a legacy Cydia repository if you are using Sileo: `https://apt.thebigboss.org/repofiles/cydia/`
+* [SSL Kill Switch 2](https://julioverne.github.io/description.html?id=com.julioverne.sslkillswitch2) (if you want to bypass certificate pinning)
 
 You may need to respring after installing the packages.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Depending on the capabilities and features you want to use, you need to install 
 
 * [OpenSSH](sileo://package/openssh) (for the `ssh` capability)
 * [SQLite 3.x](sileo://package/sqlite3) (if you want to set app permissions)
-* [Frida](sileo://package/re.frida.server) (for the `frida` capability), you will need to [add the Frida repository to Cydia/Sileo](https://frida.re/docs/ios/#with-jailbreak): `https://build.frida.re`
+* [Frida](sileo://package/re.frida.server) version 16.0.11 or greater (for the `frida` capability), you will need to [add the Frida repository to Cydia/Sileo](https://frida.re/docs/ios/#with-jailbreak): `https://build.frida.re`
 * [Open](http://cydia.saurik.com/package/com.conradkramer.open/) (if you want to launch apps without the `frida` capability), you will need to add a legacy Cydia repository if you are using Sileo: `https://apt.thebigboss.org/repofiles/cydia/`
 * [SSL Kill Switch 2](https://julioverne.github.io/description.html?id=com.julioverne.sslkillswitch2) (if you want to bypass certificate pinning)
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For the `certificate-pinning-bypass` capability, you need to install [`objection
 
 ### Host dependencies for iOS
 
-For iOS, you need [`libimobiledevice`](https://libimobiledevice.org/). The distribution packages are fine, you don't need to build from source.
+For iOS, you need [`libimobiledevice`](https://libimobiledevice.org/) and `ideviceinstaller`. The distribution packages are fine, if available.
 
 For the `frida` capability, you need to install [`frida-tools`](https://frida.re/docs/installation/).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:327](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L327)
+[index.ts:332](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L332)
 
 ___
 
@@ -77,7 +77,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:333](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L333)
+[index.ts:338](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L338)
 
 ___
 
@@ -89,7 +89,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:329](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L329)
+[ios.ts:382](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L382)
 
 ___
 
@@ -119,9 +119,9 @@ Functions that are available for the platforms.
 | `getPidForAppId` | (`appId`: `string`) => `Promise`<`number` \| `undefined`\> | Get the PID of the app with the given app ID if it is currently running. Requires the `frida` capability on iOS. |
 | `getPrefs` | (`appId`: `string`) => `Promise`<`Record`<`string`, `unknown`\> \| `undefined`\> | Get the preferences (`SharedPreferences` on Android, `NSUserDefaults` on iOS) of the app with the given app ID. Requires the `frida` capability on Android and iOS. |
 | `installApp` | (`appPath`: `string`) => `Promise`<`void`\> | Install the app at the given path. **`Todo`** How to handle split APKs on Android (#4)? |
-| `installCertificateAuthority` | `Platform` extends ``"android"`` ? (`path`: `string`) => `Promise`<`void`\> : `never` | Install the certificate authority with the given path as a trusted CA on the device. This allows you to intercept and modify traffic from apps on the device. On Android, this installs the CA as a system CA. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and installs the CA there. This means that the changes are not persistent across reboots. Currently only supported on Android. This requires the `root` capability on Android. **`Param`** The path to the certificate authority to install. |
+| `installCertificateAuthority` | (`path`: `string`) => `Promise`<`void`\> | Install the certificate authority with the given path as a trusted CA on the device. This allows you to intercept and modify traffic from apps on the device. On Android, this installs the CA as a system CA. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and installs the CA there. This means that the changes are not persistent across reboots. On iOS, the CA is installed permanently as a root certificate in the Certificate Trust Store. It persists across reboots.\ **Currently, you need to manually trust any CA at least once on the device, CAs can be added but not automatically marked as trusted (see: https://github.com/tweaselORG/appstraction/issues/44#issuecomment-1466151197).** Requires the `root` capability on Android, and the `ssh` capability on iOS. |
 | `isAppInstalled` | `Platform` extends ``"android"`` ? (`appId`: `string`) => `Promise`<`boolean`\> : `never` | Check whether the app with the given app ID is installed. Currently only supported on Android. **`Param`** The app ID of the app to check. |
-| `removeCertificateAuthority` | `Platform` extends ``"android"`` ? (`path`: `string`) => `Promise`<`void`\> : `never` | Remove the certificate authority with the given path from the trusted CAs on the device. On Android, this works for system CAs, including those pre-installed with the OS. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and removes the CA there. This means that the changes are not persistent across reboots. Currently only supported on Android. This requires the `root` capability on Android. **`Param`** The path to the certificate authority to remove. |
+| `removeCertificateAuthority` | (`path`: `string`) => `Promise`<`void`\> | Remove the certificate authority with the given path from the trusted CAs on the device. On Android, this works for system CAs, including those pre-installed with the OS. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and removes the CA there. This means that the changes are not persistent across reboots. On iOS, this only works for CAs in the Certificate Trust Store. It does not work for pre-installed OS CAs. The changes are persistent across reboots. Requires the `root` capability on Android, and the `ssh` capability on iOS. |
 | `resetDevice` | `Platform` extends ``"android"`` ? `RunTarget` extends ``"emulator"`` ? (`snapshotName`: `string`) => `Promise`<`void`\> : `never` : `never` | Reset the device to the specified snapshot (only available for emulators). **`Param`** The name of the snapshot to reset to. |
 | `setAppBackgroundBatteryUsage` | `Platform` extends ``"android"`` ? (`appId`: `string`, `state`: ``"unrestricted"`` \| ``"optimized"`` \| ``"restricted"``) => `Promise`<`void`\> : `never` | Configure whether the app's background battery usage should be restricted. Currently only supported on Android. **`Param`** The app ID of the app to configure the background battery usage settings for. **`Param`** The state to set the background battery usage to. On Android, the possible values are: - `unrestricted`: "Allow battery usage in background without restrictions. May use more battery." - `optimized`: "Optimize based on your usage. Recommended for most apps." (default after installation) - `restricted`: "Restrict battery usage while in background. Apps may not work as expected. Notifications may be delayed." |
 | `setAppPermissions` | (`appId`: `string`, `permissions?`: `Platform` extends ``"ios"`` ? { [p in IosPermission]?: "unset" \| "allow" \| "deny" } & { `location?`: ``"ask"`` \| ``"never"`` \| ``"always"`` \| ``"while-using"``  } : `Partial`<`Record`<`LiteralUnion`<[`AndroidPermission`](README.md#androidpermission), `string`\>, ``"allow"`` \| ``"deny"``\>\>) => `Promise`<`void`\> | Set the permissions for the app with the given app ID. By default, it will grant all known permissions (including dangerous permissions on Android) and set the location permission on iOS to `always`. You can specify which permissions to grant/deny using the `permissions` argument. Requires the `ssh` and `frida` capabilities on iOS. |
@@ -153,7 +153,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:265](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L265)
+[index.ts:270](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L270)
 
 ___
 
@@ -172,7 +172,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:341](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L341)
+[index.ts:346](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L346)
 
 ___
 
@@ -202,7 +202,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:292](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L292)
+[index.ts:297](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L297)
 
 ___
 
@@ -220,7 +220,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:320](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L320)
+[index.ts:325](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L325)
 
 ___
 
@@ -262,7 +262,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:348](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L348)
+[index.ts:353](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L353)
 
 ## Variables
 
@@ -286,7 +286,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:312](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L312)
+[ios.ts:365](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L365)
 
 ## Functions
 
@@ -366,4 +366,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:357](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L357)
+[index.ts:362](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L362)

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:332](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L332)
+[index.ts:330](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L330)
 
 ___
 
@@ -77,7 +77,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:338](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L338)
+[index.ts:336](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L336)
 
 ___
 
@@ -89,7 +89,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:389](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L389)
+[ios.ts:398](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L398)
 
 ___
 
@@ -120,7 +120,7 @@ Functions that are available for the platforms.
 | `getPrefs` | (`appId`: `string`) => `Promise`<`Record`<`string`, `unknown`\> \| `undefined`\> | Get the preferences (`SharedPreferences` on Android, `NSUserDefaults` on iOS) of the app with the given app ID. Requires the `frida` capability on Android and iOS. |
 | `installApp` | (`appPath`: `string`) => `Promise`<`void`\> | Install the app at the given path. **`Todo`** How to handle split APKs on Android (#4)? |
 | `installCertificateAuthority` | (`path`: `string`) => `Promise`<`void`\> | Install the certificate authority with the given path as a trusted CA on the device. This allows you to intercept and modify traffic from apps on the device. On Android, this installs the CA as a system CA. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and installs the CA there. This means that the changes are not persistent across reboots. On iOS, the CA is installed permanently as a root certificate in the Certificate Trust Store. It persists across reboots.\ **Currently, you need to manually trust any CA at least once on the device, CAs can be added but not automatically marked as trusted (see: https://github.com/tweaselORG/appstraction/issues/44#issuecomment-1466151197).** Requires the `root` capability on Android, and the `ssh` capability on iOS. |
-| `isAppInstalled` | `Platform` extends ``"android"`` ? (`appId`: `string`) => `Promise`<`boolean`\> : `never` | Check whether the app with the given app ID is installed. Currently only supported on Android. **`Param`** The app ID of the app to check. |
+| `isAppInstalled` | (`appId`: `string`) => `Promise`<`boolean`\> | Check whether the app with the given app ID is installed. |
 | `removeCertificateAuthority` | (`path`: `string`) => `Promise`<`void`\> | Remove the certificate authority with the given path from the trusted CAs on the device. On Android, this works for system CAs, including those pre-installed with the OS. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and removes the CA there. This means that the changes are not persistent across reboots. On iOS, this only works for CAs in the Certificate Trust Store. It does not work for pre-installed OS CAs. The changes are persistent across reboots. Requires the `root` capability on Android, and the `ssh` capability on iOS. |
 | `resetDevice` | `Platform` extends ``"android"`` ? `RunTarget` extends ``"emulator"`` ? (`snapshotName`: `string`) => `Promise`<`void`\> : `never` : `never` | Reset the device to the specified snapshot (only available for emulators). **`Param`** The name of the snapshot to reset to. |
 | `setAppBackgroundBatteryUsage` | `Platform` extends ``"android"`` ? (`appId`: `string`, `state`: ``"unrestricted"`` \| ``"optimized"`` \| ``"restricted"``) => `Promise`<`void`\> : `never` | Configure whether the app's background battery usage should be restricted. Currently only supported on Android. **`Param`** The app ID of the app to configure the background battery usage settings for. **`Param`** The state to set the background battery usage to. On Android, the possible values are: - `unrestricted`: "Allow battery usage in background without restrictions. May use more battery." - `optimized`: "Optimize based on your usage. Recommended for most apps." (default after installation) - `restricted`: "Restrict battery usage while in background. Apps may not work as expected. Notifications may be delayed." |
@@ -153,7 +153,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:270](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L270)
+[index.ts:268](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L268)
 
 ___
 
@@ -172,7 +172,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:346](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L346)
+[index.ts:344](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L344)
 
 ___
 
@@ -202,7 +202,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:297](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L297)
+[index.ts:295](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L295)
 
 ___
 
@@ -220,7 +220,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:325](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L325)
+[index.ts:323](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L323)
 
 ___
 
@@ -262,7 +262,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:353](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L353)
+[index.ts:351](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L351)
 
 ## Variables
 
@@ -286,7 +286,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:372](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L372)
+[ios.ts:381](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L381)
 
 ## Functions
 
@@ -366,4 +366,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:362](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L362)
+[index.ts:360](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L360)

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:639](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L639)
+[android.ts:640](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L640)
 
 ___
 
@@ -274,7 +274,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:508](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L508)
+[android.ts:509](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L509)
 
 ___
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:639](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L639)
+[android.ts:639](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L639)
 
 ___
 
@@ -58,7 +58,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:324](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L324)
+[index.ts:327](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L327)
 
 ___
 
@@ -77,7 +77,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:330](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L330)
+[index.ts:333](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L333)
 
 ___
 
@@ -89,7 +89,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:222](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L222)
+[ios.ts:329](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L329)
 
 ___
 
@@ -126,14 +126,14 @@ Functions that are available for the platforms.
 | `setAppBackgroundBatteryUsage` | `Platform` extends ``"android"`` ? (`appId`: `string`, `state`: ``"unrestricted"`` \| ``"optimized"`` \| ``"restricted"``) => `Promise`<`void`\> : `never` | Configure whether the app's background battery usage should be restricted. Currently only supported on Android. **`Param`** The app ID of the app to configure the background battery usage settings for. **`Param`** The state to set the background battery usage to. On Android, the possible values are: - `unrestricted`: "Allow battery usage in background without restrictions. May use more battery." - `optimized`: "Optimize based on your usage. Recommended for most apps." (default after installation) - `restricted`: "Restrict battery usage while in background. Apps may not work as expected. Notifications may be delayed." |
 | `setAppPermissions` | (`appId`: `string`, `permissions?`: `Platform` extends ``"ios"`` ? { [p in IosPermission]?: "unset" \| "allow" \| "deny" } & { `location?`: ``"ask"`` \| ``"never"`` \| ``"always"`` \| ``"while-using"``  } : `Partial`<`Record`<`LiteralUnion`<[`AndroidPermission`](README.md#androidpermission), `string`\>, ``"allow"`` \| ``"deny"``\>\>) => `Promise`<`void`\> | Set the permissions for the app with the given app ID. By default, it will grant all known permissions (including dangerous permissions on Android) and set the location permission on iOS to `always`. You can specify which permissions to grant/deny using the `permissions` argument. Requires the `ssh` and `frida` capabilities on iOS. |
 | `setClipboard` | (`text`: `string`) => `Promise`<`void`\> | Set the clipboard to the given text. Requires the `frida` capability on Android and iOS. |
-| `setProxy` | `Platform` extends ``"android"`` ? (`proxy`: ``"wireguard"`` extends `Capability` ? [`WireGuardConfig`](README.md#wireguardconfig) : [`Proxy`](README.md#proxy) \| ``null``) => `Promise`<`void`\> : `never` | Set or disable the proxy on the device. If you have enabled the `wireguard` capability, this will start or stop a WireGuard tunnel. Otherwise, it will set the global proxy on the device. Currently only supported on Android. Enabling a WireGuard tunnel requires the `root` capability on Android. **`Remarks`** The WireGuard integration will create a new tunnel in the app called `appstraction` and delete it when the proxy is stopped. If you have an existing tunnel with the same name, it will be overridden. **`Param`** The proxy to set, or `null` to disable the proxy. If you have enabled the `wireguard` capability, this is a string of the full WireGuard configuration to use. |
+| `setProxy` | `Platform` extends ``"android"`` ? (`proxy`: ``"wireguard"`` extends `Capability` ? [`WireGuardConfig`](README.md#wireguardconfig) : [`Proxy`](README.md#proxy) \| ``null``) => `Promise`<`void`\> : `Platform` extends ``"ios"`` ? (`proxy`: [`Proxy`](README.md#proxy) \| ``null``) => `Promise`<`void`\> : `never` | Set or disable the proxy on the device. If you have enabled the `wireguard` capability, this will start or stop a WireGuard tunnel. Otherwise, it will set the global proxy on the device. On iOS, the proxy is set for the current WiFi network. It won't apply for other networks or for cellular data connections. WireGuard is currently only supported on Android. Enabling a WireGuard tunnel requires the `root` capability. **`Remarks`** The WireGuard integration will create a new tunnel in the app called `appstraction` and delete it when the proxy is stopped. If you have an existing tunnel with the same name, it will be overridden. **`Param`** The proxy to set, or `null` to disable the proxy. If you have enabled the `wireguard` capability, this is a string of the full WireGuard configuration to use. |
 | `startApp` | (`appId`: `string`) => `Promise`<`void`\> | Start the app with the given app ID. Doesn't wait for the app to be ready. Also enables the certificate pinning bypass if enabled. Requires the `frida` or `ssh` capability on iOS. On Android, this will start the app with or without a certificate pinning bypass depending on the `certificate-pinning-bypass` capability. |
 | `stopApp` | `Platform` extends ``"android"`` ? (`appId`: `string`) => `Promise`<`void`\> : `never` | Force-stop the app with the given app ID. **`Param`** The app ID of the app to stop. |
 | `uninstallApp` | (`appId`: `string`) => `Promise`<`void`\> | Uninstall the app with the given app ID. Will not fail if the app is not installed. This also removes any data stored by the app. |
 
 #### Defined in
 
-[index.ts:18](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L18)
+[index.ts:18](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L18)
 
 ___
 
@@ -153,7 +153,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:262](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L262)
+[index.ts:265](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L265)
 
 ___
 
@@ -172,7 +172,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:338](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L338)
+[index.ts:341](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L341)
 
 ___
 
@@ -202,7 +202,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:289](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L289)
+[index.ts:292](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L292)
 
 ___
 
@@ -220,7 +220,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:317](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L317)
+[index.ts:320](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L320)
 
 ___
 
@@ -232,7 +232,7 @@ A platform that is supported by this library.
 
 #### Defined in
 
-[index.ts:9](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L9)
+[index.ts:9](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L9)
 
 ___
 
@@ -250,7 +250,7 @@ A run target that is supported by this library for the given platform.
 
 #### Defined in
 
-[index.ts:11](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L11)
+[index.ts:11](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L11)
 
 ___
 
@@ -262,7 +262,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:345](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L345)
+[index.ts:348](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L348)
 
 ## Variables
 
@@ -274,7 +274,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:508](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L508)
+[android.ts:508](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L508)
 
 ___
 
@@ -286,7 +286,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:205](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L205)
+[ios.ts:312](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L312)
 
 ## Functions
 
@@ -312,7 +312,7 @@ The an object with the app ID and version, or `undefined` if the file doesn't ex
 
 #### Defined in
 
-[util.ts:49](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L49)
+[util.ts:50](https://github.com/tweaselORG/platform-apis/blob/main/src/util.ts#L50)
 
 ___
 
@@ -334,7 +334,7 @@ Pause for a given duration.
 
 #### Defined in
 
-[util.ts:35](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L35)
+[util.ts:36](https://github.com/tweaselORG/platform-apis/blob/main/src/util.ts#L36)
 
 ___
 
@@ -366,4 +366,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:354](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L354)
+[index.ts:357](https://github.com/tweaselORG/platform-apis/blob/main/src/index.ts#L357)

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:382](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L382)
+[ios.ts:389](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L389)
 
 ___
 
@@ -128,7 +128,7 @@ Functions that are available for the platforms.
 | `setClipboard` | (`text`: `string`) => `Promise`<`void`\> | Set the clipboard to the given text. Requires the `frida` capability on Android and iOS. |
 | `setProxy` | `Platform` extends ``"android"`` ? (`proxy`: ``"wireguard"`` extends `Capability` ? [`WireGuardConfig`](README.md#wireguardconfig) : [`Proxy`](README.md#proxy) \| ``null``) => `Promise`<`void`\> : `Platform` extends ``"ios"`` ? (`proxy`: [`Proxy`](README.md#proxy) \| ``null``) => `Promise`<`void`\> : `never` | Set or disable the proxy on the device. If you have enabled the `wireguard` capability, this will start or stop a WireGuard tunnel. Otherwise, it will set the global proxy on the device. On iOS, the proxy is set for the current WiFi network. It won't apply for other networks or for cellular data connections. WireGuard is currently only supported on Android. Enabling a WireGuard tunnel requires the `root` capability. **`Remarks`** The WireGuard integration will create a new tunnel in the app called `appstraction` and delete it when the proxy is stopped. If you have an existing tunnel with the same name, it will be overridden. **`Param`** The proxy to set, or `null` to disable the proxy. If you have enabled the `wireguard` capability, this is a string of the full WireGuard configuration to use. |
 | `startApp` | (`appId`: `string`) => `Promise`<`void`\> | Start the app with the given app ID. Doesn't wait for the app to be ready. Also enables the certificate pinning bypass if enabled. Requires the `frida` or `ssh` capability on iOS. On Android, this will start the app with or without a certificate pinning bypass depending on the `certificate-pinning-bypass` capability. |
-| `stopApp` | `Platform` extends ``"android"`` ? (`appId`: `string`) => `Promise`<`void`\> : `never` | Force-stop the app with the given app ID. **`Param`** The app ID of the app to stop. |
+| `stopApp` | (`appId`: `string`) => `Promise`<`void`\> | Force-stop the app with the given app ID. |
 | `uninstallApp` | (`appId`: `string`) => `Promise`<`void`\> | Uninstall the app with the given app ID. Will not fail if the app is not installed. This also removes any data stored by the app. |
 
 #### Defined in
@@ -286,7 +286,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:365](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L365)
+[ios.ts:372](https://github.com/tweaselORG/platform-apis/blob/main/src/ios.ts#L372)
 
 ## Functions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:640](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L640)
+[android.ts:714](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L714)
 
 ___
 
@@ -274,7 +274,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:509](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L509)
+[android.ts:583](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L583)
 
 ___
 

--- a/examples/ios-device.ts
+++ b/examples/ios-device.ts
@@ -2,7 +2,7 @@
 import { parseAppMeta, pause, platformApi } from '../src/index';
 
 // You can pass the following command line arguments:
-// `npx tsx examples/ios-device.ts <ip> <app path> <proxy host?> <proxy port?>`
+// `npx tsx examples/ios-device.ts <ip> <app path> <CA cert path?> <proxy host?> <proxy port?>`
 
 (async () => {
     const ios = platformApi({
@@ -15,11 +15,18 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
     });
 
     const appPath = process.argv[3] || '/path/to/app-files';
-    const proxyHost = process.argv[4];
-    const proxyPort = process.argv[5];
+    const caCertPath = process.argv[4];
+    const proxyHost = process.argv[5];
+    const proxyPort = process.argv[6];
 
     await ios.ensureDevice();
 
+    if (caCertPath) {
+        await ios.installCertificateAuthority(caCertPath);
+        console.log(
+            'Installed CA. Note that it will currently not be automatically trusted unless you have manually trusted any user CA at least once before.'
+        );
+    }
     if (proxyHost && proxyPort) await ios.setProxy({ host: proxyHost, port: +proxyPort });
 
     await ios.setClipboard('I copied this.');
@@ -50,5 +57,6 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
     await ios.uninstallApp(appId);
 
     if (proxyHost && proxyPort) await ios.setProxy(null);
+    if (caCertPath) await ios.removeCertificateAuthority(caCertPath);
 })();
 /* eslint-enable no-console */

--- a/examples/ios-device.ts
+++ b/examples/ios-device.ts
@@ -2,7 +2,7 @@
 import { parseAppMeta, pause, platformApi } from '../src/index';
 
 // You can pass the following command line arguments:
-// `npx tsx examples/ios-device.ts <ip> <app path>`
+// `npx tsx examples/ios-device.ts <ip> <app path> <proxy host?> <proxy port?>`
 
 (async () => {
     const ios = platformApi({
@@ -15,8 +15,12 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
     });
 
     const appPath = process.argv[3] || '/path/to/app-files';
+    const proxyHost = process.argv[4];
+    const proxyPort = process.argv[5];
 
     await ios.ensureDevice();
+
+    if (proxyHost && proxyPort) await ios.setProxy({ host: proxyHost, port: +proxyPort });
 
     await ios.setClipboard('I copied this.');
 
@@ -44,5 +48,7 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
     // `clearStuckModals()` is currently broken on iOS (see https://github.com/tweaselORG/appstraction/issues/12).
     // await ios.clearStuckModals();
     await ios.uninstallApp(appId);
+
+    if (proxyHost && proxyPort) await ios.setProxy(null);
 })();
 /* eslint-enable no-console */

--- a/examples/ios-device.ts
+++ b/examples/ios-device.ts
@@ -36,6 +36,8 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
     const appId = appMeta.id;
     console.log('App:', appId, '@', appMeta.version);
 
+    console.log('Installed already?', await ios.isAppInstalled(appId));
+
     await ios.installApp(appPath);
     // First, grant all permissions.
     await ios.setAppPermissions(appId);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     },
     "prettier": "@baltpeter/prettier-config",
     "dependencies": {
+        "@napi-rs/lzma": "^1.1.2",
         "cross-fetch": "^3.1.5",
         "execa": "^6.1.0",
         "frida": "^16.0.8",
@@ -58,6 +59,7 @@
         "ipa-extract-info": "^1.2.6",
         "p-retry": "^5.1.2",
         "pkijs": "^3.0.14",
+        "semver": "^7.3.8",
         "tempy": "^3.0.0",
         "ts-node": "^10.9.1"
     },
@@ -71,6 +73,7 @@
         "@types/node": "^18.11.18",
         "@types/plist": "^3.0.2",
         "@types/promise-timeout": "^1.3.0",
+        "@types/semver": "^7.3.13",
         "@typescript-eslint/eslint-plugin": "5.48.0",
         "eslint": "8.31.0",
         "eslint-plugin-eslint-comments": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "frida": "^16.0.8",
         "fs-extra": "^11.1.0",
         "ipa-extract-info": "^1.2.6",
+        "p-retry": "^5.1.2",
         "pkijs": "^3.0.14",
         "tempy": "^3.0.0",
         "ts-node": "^10.9.1"

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "frida": "^16.0.8",
         "fs-extra": "^11.1.0",
         "ipa-extract-info": "^1.2.6",
+        "pkijs": "^3.0.14",
         "tempy": "^3.0.0",
         "ts-node": "^10.9.1"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,13 +199,17 @@ export type PlatformApi<
      * overlays the `/system/etc/security/cacerts` directory with a tmpfs and installs the CA there. This means that the
      * changes are not persistent across reboots.
      *
-     * Currently only supported on Android.
+     * On iOS, the CA is installed permanently as a root certificate in the Certificate Trust Store. It persists across
+     * reboots.\
+     * **Currently, you need to manually trust any CA at least once on the device, CAs can be added but not
+     * automatically marked as trusted (see:
+     * https://github.com/tweaselORG/appstraction/issues/44#issuecomment-1466151197).**
      *
-     * This requires the `root` capability on Android.
+     * Requires the `root` capability on Android, and the `ssh` capability on iOS.
      *
-     * @param path The path to the certificate authority to install.
+     * @param path The path to the certificate authority to install. The certificate must be in PEM format.
      */
-    installCertificateAuthority: Platform extends 'android' ? (path: string) => Promise<void> : never;
+    installCertificateAuthority: (path: string) => Promise<void>;
     /**
      * Remove the certificate authority with the given path from the trusted CAs on the device.
      *
@@ -213,13 +217,14 @@ export type PlatformApi<
      * possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and
      * removes the CA there. This means that the changes are not persistent across reboots.
      *
-     * Currently only supported on Android.
+     * On iOS, this only works for CAs in the Certificate Trust Store. It does not work for pre-installed OS CAs. The
+     * changes are persistent across reboots.
      *
-     * This requires the `root` capability on Android.
+     * Requires the `root` capability on Android, and the `ssh` capability on iOS.
      *
-     * @param path The path to the certificate authority to remove.
+     * @param path The path to the certificate authority to remove. The certificate must be in PEM format.
      */
-    removeCertificateAuthority: Platform extends 'android' ? (path: string) => Promise<void> : never;
+    removeCertificateAuthority: (path: string) => Promise<void>;
     /**
      * Set or disable the proxy on the device. If you have enabled the `wireguard` capability, this will start or stop a
      * WireGuard tunnel. Otherwise, it will set the global proxy on the device.

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,13 +50,11 @@ export type PlatformApi<
     /**
      * Check whether the app with the given app ID is installed.
      *
-     * Currently only supported on Android.
-     *
      * @param appId The app ID of the app to check.
      *
      * @returns Whether the app is installed.
      */
-    isAppInstalled: Platform extends 'android' ? (appId: string) => Promise<boolean> : never;
+    isAppInstalled: (appId: string) => Promise<boolean>;
     /**
      * Install the app at the given path.
      *

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ export type PlatformApi<
      *
      * @param appId The app ID of the app to stop.
      */
-    stopApp: Platform extends 'android' ? (appId: string) => Promise<void> : never;
+    stopApp: (appId: string) => Promise<void>;
 
     /**
      * Get the app ID of the running app that is currently in the foreground.

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,9 +224,10 @@ export type PlatformApi<
      * Set or disable the proxy on the device. If you have enabled the `wireguard` capability, this will start or stop a
      * WireGuard tunnel. Otherwise, it will set the global proxy on the device.
      *
-     * Currently only supported on Android.
+     * On iOS, the proxy is set for the current WiFi network. It won't apply for other networks or for cellular data
+     * connections.
      *
-     * Enabling a WireGuard tunnel requires the `root` capability on Android.
+     * WireGuard is currently only supported on Android. Enabling a WireGuard tunnel requires the `root` capability.
      *
      * @remarks
      * The WireGuard integration will create a new tunnel in the app called `appstraction` and delete it when the proxy
@@ -236,6 +237,8 @@ export type PlatformApi<
      */
     setProxy: Platform extends 'android'
         ? (proxy: ('wireguard' extends Capability ? WireGuardConfig : Proxy) | null) => Promise<void>
+        : Platform extends 'ios'
+        ? (proxy: Proxy | null) => Promise<void>
         : never;
 
     /** @ignore */

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -154,7 +154,16 @@ export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
     },
     clearStuckModals: asyncUnimplemented('clearStuckModals') as never,
 
-    isAppInstalled: asyncUnimplemented('isAppInstalled') as never,
+    isAppInstalled: async (appId) => {
+        const { stdout } = await execa('ideviceinstaller', ['-l', '-o', 'list_all']);
+        return (
+            stdout
+                .split('\n')
+                // The first line is the header.
+                .slice(1)
+                .some((l) => l.startsWith(`${appId},`))
+        );
+    },
     // We're using `libimobiledevice` instead of `cfgutil` because the latter doesn't wait for the app to be fully
     // installed before exiting.
     installApp: async (ipaPath) => {

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -233,7 +233,14 @@ export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
             throw new Error('Frida or SSH (with the open package installed) is required for starting apps.');
         }
     },
-    stopApp: asyncUnimplemented('stopApp') as never,
+    async stopApp(appId) {
+        if (!options.capabilities.includes('frida')) throw new Error('Frida is required for stopping apps.');
+
+        const pid = await this.getPidForAppId(appId);
+        if (!pid) return;
+
+        return (await frida.getUsbDevice()).kill(pid);
+    },
 
     getForegroundAppId: async () => {
         if (!options.capabilities.includes('frida'))

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import { execa } from 'execa';
+import type { TargetProcess } from 'frida';
 import frida from 'frida';
 import fs from 'fs-extra';
 import _ipaInfo from 'ipa-extract-info';
@@ -78,10 +79,10 @@ export const ipaInfo = async (ipaPath: string) => {
     return await _ipaInfo(fd);
 };
 
-export const getObjFromFridaScript = async (pid: number | undefined, script: string) => {
-    if (!pid) throw new Error('Must provide pid.');
+export const getObjFromFridaScript = async (targetProcess: TargetProcess | undefined, script: string) => {
+    if (!targetProcess) throw new Error('Must provide targetProcess.');
     const fridaDevice = await frida.getUsbDevice();
-    const fridaSession = await fridaDevice.attach(pid);
+    const fridaSession = await fridaDevice.attach(targetProcess);
     const fridaScript = await fridaSession.createScript(script);
     const resultPromise = new Promise<unknown>((res, rej) => {
         fridaScript.message.connect((message) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "extends": "@baltpeter/tsconfig",
     "include": ["src/**/*", "examples/**/*", "src/types/ipa-extract-info.d.ts"],
     "compilerOptions": {
+        "resolveJsonModule": true,
         "paths": {
             "*": ["./*", "./src/types/*"]
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,6 +971,11 @@
   resolved "https://registry.yarnpkg.com/@types/promise-timeout/-/promise-timeout-1.3.0.tgz#90649ff6f48c1ead9de142e6dd9f62f8c5a54022"
   integrity sha512-AtVKSZUtpBoZ4SshXJk5JcTXJllinHKKx615lsRNJUsbbFlI0AI8drlnoiQ+PNvjkeoF9Y8fJUh6UO2khsIBZw==
 
+"@types/retry@0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
+  integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
+
 "@types/semver@^7.3.12":
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
@@ -3603,6 +3608,14 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-retry@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-5.1.2.tgz#c16eaee4f2016f9161d12da40d3b8b0f2e3c1b76"
+  integrity sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==
+  dependencies:
+    "@types/retry" "0.12.1"
+    retry "^0.13.1"
+
 parcel@2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.8.2.tgz#6539c0a435b14e5829d09254b0394dcfbc0b0ba5"
@@ -3966,6 +3979,11 @@ restore-cursor@^3.1.0:
   dependencies:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,90 @@
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.2.0.tgz#016d855b6bc459fd908095811f6826e45dd4ba64"
   integrity sha512-XrC0JzsqQSvOyM3t04FMLO6z5gCuhPE6k4FXuLK5xf52ZbdvcFe1yBmo7meCew9B8G2f0T9iu9t3kfTYRYROgA==
 
+"@napi-rs/lzma-android-arm-eabi@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-android-arm-eabi/-/lzma-android-arm-eabi-1.1.2.tgz#3866356a277ead52c6a04abff3600ad52e45d2e6"
+  integrity sha512-b30+yEjSU1XucdTu2V8pGvpCVlFYlXMFHn89OjV+RhkQj4z3DwSPTZu17iea7MRSuP4bZzZkUG7t18lNDD9O4Q==
+
+"@napi-rs/lzma-android-arm64@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-android-arm64/-/lzma-android-arm64-1.1.2.tgz#6a4dcd77909c45710a598d99a769382356779ca9"
+  integrity sha512-SW83wFds4AK4+eNnFl8bN25ypZU12/dae3h4wxz4l1czNsxomr4zN/feuymDzRURFU1nJti4lLK6fmRJW4ej5g==
+
+"@napi-rs/lzma-darwin-arm64@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-darwin-arm64/-/lzma-darwin-arm64-1.1.2.tgz#7074cf0ce8a2d805b163d57f321df7f93c8ea70a"
+  integrity sha512-YM3SDU5Stt+M5tR8FQke5Puk6KIWOnSb+cfNbaM4zRvASpJVqdCEpblaSsgyuhsCfC8VjeEfohL4hkuAq5Ovzw==
+
+"@napi-rs/lzma-darwin-x64@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-darwin-x64/-/lzma-darwin-x64-1.1.2.tgz#9d1e51fd4037eb0722f9cae9c8b51b5c6e17c36a"
+  integrity sha512-CO+mXmUIyUZZcQngGK5vY71xBNMbgfA3tu4QVkExlQE/JfeQ+JiIOB/ksOMNMkBJdK12nSrFitCUyuZ0eS8JXQ==
+
+"@napi-rs/lzma-freebsd-x64@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-freebsd-x64/-/lzma-freebsd-x64-1.1.2.tgz#08b98cbc19e3e6db8ce81a95b1a791243bf32995"
+  integrity sha512-Za+QobA52xOMSlT2n30TFtA200qfZKPgSuDjVqURc+DyzcQLgG94n+C+J1YoY0iyfvlRdK0P32MBPHSq5fN/Fw==
+
+"@napi-rs/lzma-linux-arm-gnueabihf@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-linux-arm-gnueabihf/-/lzma-linux-arm-gnueabihf-1.1.2.tgz#6119d1718d82ac61ccfbb6413c24d9deef87f32b"
+  integrity sha512-DBLyr61rcsmjbBPiUag0O2CDUZ/g+puCqRQdgXIQkH6pDV+Mn7ey2xq12eBwmoB4qASL1xU1SVChBWjO7HIwdg==
+
+"@napi-rs/lzma-linux-arm64-gnu@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-linux-arm64-gnu/-/lzma-linux-arm64-gnu-1.1.2.tgz#2da3ee85b9fb1a6e8dd13dd09e29975abc9e433e"
+  integrity sha512-nR5nnc3tnXZyd1jn9dHarj8RQeUJmvm83Z46mfWFKBv/TtlP4U7eyg9n3A0eEyBTifPzuR5ZjVdaMXg0hrX9cA==
+
+"@napi-rs/lzma-linux-arm64-musl@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-linux-arm64-musl/-/lzma-linux-arm64-musl-1.1.2.tgz#be737c17646d5088a430ca6df0146f43aa05c63e"
+  integrity sha512-N4gC6VJds/wL6PY23Cc8Z3QuztIMpNfBo++zLu2uHdRV67/XkM7JXfsgTCaZVR59lSZw+Pvi01w5i00BhmEZ/g==
+
+"@napi-rs/lzma-linux-x64-gnu@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.1.2.tgz#7e7b890e4a8b8917d7733dff036e962b8cbafd7b"
+  integrity sha512-xfSXofZnDlbSik64AayKj5xgSVmYMsK1cmRPQGBDcpwK4qnFd+Sy/qa39+x+GT2pip9QnT6stb72BT69asTRbw==
+
+"@napi-rs/lzma-linux-x64-musl@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-linux-x64-musl/-/lzma-linux-x64-musl-1.1.2.tgz#47d0b6d7deb17b3a35b9293ae9231325aec314a8"
+  integrity sha512-wfrv3zRK+qw3+GT3o4FPGZWb8L0gtqpjAQgPiz91EtGyHWKZjvRz31zERUkU9DKEwSBZSxYoFu5zCVsvilQekA==
+
+"@napi-rs/lzma-win32-arm64-msvc@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-win32-arm64-msvc/-/lzma-win32-arm64-msvc-1.1.2.tgz#2582d99f20baf693bb609d0ddcaf69e49f2fdf16"
+  integrity sha512-9lwYWz4g3FMxt5Pu33jfGuoHvAnXaonXYMbjWCVq3t+ReHV38rEVnueWtJD2GQcrnV2Elu0zxU4zON1PwJ1KqQ==
+
+"@napi-rs/lzma-win32-ia32-msvc@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-win32-ia32-msvc/-/lzma-win32-ia32-msvc-1.1.2.tgz#d38dbb8f48b3050a17a0dd3c33a8197341624370"
+  integrity sha512-p9ZuF/5osCKES5oz5ZKyMck9jbVBhZ/zH4uD6fsKjLtp0VYBlvmfqSGUYQALkF6bqvL7xBeJz7qby416pnWqPg==
+
+"@napi-rs/lzma-win32-x64-msvc@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma-win32-x64-msvc/-/lzma-win32-x64-msvc-1.1.2.tgz#dbc715b85e8f15363959af1dbb08844e2214c177"
+  integrity sha512-EwNN9eH05KkeqO300UEYqZEbqzRD3R4anUJMIvhmJI1E3a/9mUbzEByrSBsjyPfYcHF5+KYenEpuPoup9a4eHQ==
+
+"@napi-rs/lzma@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@napi-rs/lzma/-/lzma-1.1.2.tgz#09ce791390d819918182fe9382a7075e90d21d55"
+  integrity sha512-WJLn/td0F7RQmQ0mhtGVQXjfXQND8CE9hAdHJovPm6fM3aNW68chn7DCAyhs7rmhX95PovTEP0iu9TZVUtnl3w==
+  optionalDependencies:
+    "@napi-rs/lzma-android-arm-eabi" "1.1.2"
+    "@napi-rs/lzma-android-arm64" "1.1.2"
+    "@napi-rs/lzma-darwin-arm64" "1.1.2"
+    "@napi-rs/lzma-darwin-x64" "1.1.2"
+    "@napi-rs/lzma-freebsd-x64" "1.1.2"
+    "@napi-rs/lzma-linux-arm-gnueabihf" "1.1.2"
+    "@napi-rs/lzma-linux-arm64-gnu" "1.1.2"
+    "@napi-rs/lzma-linux-arm64-musl" "1.1.2"
+    "@napi-rs/lzma-linux-x64-gnu" "1.1.2"
+    "@napi-rs/lzma-linux-x64-musl" "1.1.2"
+    "@napi-rs/lzma-win32-arm64-msvc" "1.1.2"
+    "@napi-rs/lzma-win32-ia32-msvc" "1.1.2"
+    "@napi-rs/lzma-win32-x64-msvc" "1.1.2"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -976,7 +1060,7 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
   integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
 
-"@types/semver@^7.3.12":
+"@types/semver@^7.3.12", "@types/semver@^7.3.13":
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
@@ -4057,7 +4141,7 @@ semver@^5.7.0, semver@^5.7.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^7.3.5, semver@^7.3.7:
+semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,6 +1208,15 @@ array.prototype.flat@^1.2.5:
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
 
+asn1js@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/asn1js/-/asn1js-3.0.5.tgz#5ea36820443dbefb51cc7f88a2ebb5b462114f38"
+  integrity sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==
+  dependencies:
+    pvtsutils "^1.3.2"
+    pvutils "^1.1.3"
+    tslib "^2.4.0"
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -1353,6 +1362,11 @@ buffer@^5.5.0:
   dependencies:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
+
+bytestreamjs@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/bytestreamjs/-/bytestreamjs-2.0.1.tgz#a32947c7ce389a6fa11a09a9a563d0a45889535e"
+  integrity sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -3688,6 +3702,17 @@ pkg-dir@^5.0.0:
   dependencies:
     find-up "^5.0.0"
 
+pkijs@^3.0.14:
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/pkijs/-/pkijs-3.0.14.tgz#92571f61122fd1e0ccdbc328b6efab9467b0bc30"
+  integrity sha512-Fi9++44BaOY0VcOEJql27D/HzHIeMU9R48XclfL98Cp8Wh/gGfPbuS1RUwReHQHRIUfzW32eoNO1izxoBMZi6w==
+  dependencies:
+    asn1js "^3.0.5"
+    bytestreamjs "^2.0.0"
+    pvtsutils "^1.3.2"
+    pvutils "^1.1.3"
+    tslib "^2.4.0"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -3790,6 +3815,18 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pvtsutils@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/pvtsutils/-/pvtsutils-1.3.2.tgz#9f8570d132cdd3c27ab7d51a2799239bf8d8d5de"
+  integrity sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==
+  dependencies:
+    tslib "^2.4.0"
+
+pvutils@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.3.tgz#f35fc1d27e7cd3dfbd39c0826d173e806a03f5a3"
+  integrity sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION
With this PR, I'm catching iOS up with the new features added for Android in #27.

**This is based on #27, which needs to be merged first.**

Functions implemented so far:

* `installCertificateAuthority()` and `removeCertificateAuthority()` to install or remove a certificate authority as a trusted root CA on the device. Caveat: For the CA to be trusted automatically, the user needs to perform a one-time setup step. (#44)
* `setProxy()` to either set or disable the global proxy settings. (#25)

Additionally implemented:

* `stopApp()` to force-stop an app. (#37)
* `isAppInstalled()` to check whether an app is already installed on the device. (#41)

Unrelated to the rest of the PR but also added here (since I didn't want to stack yet another PR):

* Retry starting Frida on Android if that fails to hopefully fix #32.
* Automatically install Frida in `ensureDevice()` on Android. The device preparation instructions on Android are now delightfully short. \o/ (#39)