### PR TITLE
Related to #32: Wait for devices to boot

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:718](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L718)
+[android.ts:730](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L730)
 
 ___
 
@@ -274,7 +274,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:587](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L587)
+[android.ts:599](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L599)
 
 ___
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:714](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L714)
+[android.ts:718](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L718)
 
 ___
 
@@ -274,7 +274,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:583](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L583)
+[android.ts:587](https://github.com/tweaselORG/platform-apis/blob/main/src/android.ts#L587)
 
 ___
 

--- a/src/android.ts
+++ b/src/android.ts
@@ -46,10 +46,14 @@ export const androidApi = <RunTarget extends SupportedRunTarget<'android'>>(
         objectionProcesses: [],
 
         awaitAdb: async () => {
-            const adbIsStarted = await retryCondition(
-                async () => (await execa('adb', ['get-state'], { reject: false })).exitCode === 0,
-                100
-            );
+            const adbIsStarted = await retryCondition(async () => {
+                const { exitCode, stdout } = await execa(
+                    'adb',
+                    ['wait-for-device', 'shell', 'getprop', 'dev.bootcomplete'],
+                    { reject: false }
+                );
+                return exitCode === 0 && stdout.includes('1');
+            }, 100);
             if (!adbIsStarted) throw new Error('Failed to connect via adb.');
         },
         async ensureFrida() {


### PR DESCRIPTION
While investigating #32, I found that some commands were already running without the emulator being fully booted, yet. This caused several problems. Waiting for `dev.bootcomplete` should fix that.

This PR is based on #42, which should be merged first.