### PR TITLE
Support for custom APK bundle formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Appstraction provides an abstraction layer for common instrumentation functions 
 With appstraction, you can perform the following actions programmatically on Android and iOS (for a full list with additional details, see the API reference for the [`PlatformApi` type](docs/README.md#platformapi)):
 
 * Reset an emulator to a snapshot.
-* Install and uninstall apps (including split APKs on Android).
+* Install and uninstall apps, including split APKs and `.obb`s, apps downloaded from popular unofficial APK mirror sites (`.xapk` by APKPure, `.apkm` by APKMirror), and `.apks` files created by SAI on Android.
 * Check whether an app is installed.
 * Set an app's permissions, either granting everything or granularly specifying which permissions to grant or deny.
 * Configure an app's battery optimization settings.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,10 +47,10 @@ ___
 
 ### AppPath
 
-Ƭ **AppPath**<`Platform`\>: `Platform` extends ``"android"`` ? \`${string}.apk\` \| \`${string}.xapk\` \| \`${string}.apkm\` \| \`${string}.apk\`[] : \`${string}.ipa\`
+Ƭ **AppPath**<`Platform`\>: `Platform` extends ``"android"`` ? \`${string}.apk\` \| \`${string}.xapk\` \| \`${string}.apkm\` \| \`${string}.apks\` \| \`${string}.apk\`[] : \`${string}.ipa\`
 
 On Android, the path to a single APK with the `.apk` extension, an array of paths to split APKs with the `.apk`
-extension or the path to an XAPK file with the `.xapk` extension.
+extension, the path to an XAPK file with the `.xapk` extension or the path to either an `.apkm` or `.apks` file.
 
 On iOS, the path to an IPA file with the `.ipa` extension.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ appstraction
 - [DeviceAttribute](README.md#deviceattribute)
 - [GetDeviceAttributeOptions](README.md#getdeviceattributeoptions)
 - [IosPermission](README.md#iospermission)
+- [ObbInstallSpec](README.md#obbinstallspec)
 - [PlatformApi](README.md#platformapi)
 - [PlatformApiOptions](README.md#platformapioptions)
 - [Proxy](README.md#proxy)
@@ -41,7 +42,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:860](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L860)
+[android.ts:880](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L880)
 
 ___
 
@@ -80,7 +81,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:343](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L343)
+[index.ts:357](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L357)
 
 ___
 
@@ -99,7 +100,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:349](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L349)
+[index.ts:363](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L363)
 
 ___
 
@@ -112,6 +113,25 @@ An ID of a known permission on iOS.
 #### Defined in
 
 [ios.ts:382](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L382)
+
+___
+
+### ObbInstallSpec
+
+Ƭ **ObbInstallSpec**: `Object`
+
+An object that describes how an Android extension file (`.obb`) should be installed on the device.
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `installPath?` | \`${string}.obb\` | Path in relation to `$EXTERNAL_STORAGE` in which to install the obb on the guest. Will be the default app folder (`$EXTERNAL_STORAGE/Android/obb/<app id>/<file name on host>`) if nothing is specified. |
+| `obb` | \`${string}.obb\` | Path to the obb on the host. |
+
+#### Defined in
+
+[index.ts:28](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L28)
 
 ___
 
@@ -140,7 +160,7 @@ Functions that are available for the platforms.
 | `getForegroundAppId` | () => `Promise`<`string` \| `undefined`\> | Get the app ID of the running app that is currently in the foreground. Requires the `frida` capability on iOS. |
 | `getPidForAppId` | (`appId`: `string`) => `Promise`<`number` \| `undefined`\> | Get the PID of the app with the given app ID if it is currently running. Requires the `frida` capability on iOS. |
 | `getPrefs` | (`appId`: `string`) => `Promise`<`Record`<`string`, `unknown`\> \| `undefined`\> | Get the preferences (`SharedPreferences` on Android, `NSUserDefaults` on iOS) of the app with the given app ID. Requires the `frida` capability on Android and iOS. |
-| `installApp` | (`appPath`: [`AppPath`](README.md#apppath)<`Platform`\>) => `Promise`<`void`\> | Install the app at the given path. |
+| `installApp` | (`appPath`: [`AppPath`](README.md#apppath)<`Platform`\>, `obbPaths?`: `Platform` extends ``"android"`` ? [`ObbInstallSpec`](README.md#obbinstallspec)[] : `never`) => `Promise`<`void`\> | Install the app at the given path. |
 | `installCertificateAuthority` | (`path`: `string`) => `Promise`<`void`\> | Install the certificate authority with the given path as a trusted CA on the device. This allows you to intercept and modify traffic from apps on the device. On Android, this installs the CA as a system CA. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and installs the CA there. This means that the changes are not persistent across reboots. On iOS, the CA is installed permanently as a root certificate in the Certificate Trust Store. It persists across reboots.\ **Currently, you need to manually trust any CA at least once on the device, CAs can be added but not automatically marked as trusted (see: https://github.com/tweaselORG/appstraction/issues/44#issuecomment-1466151197).** Requires the `root` capability on Android, and the `ssh` capability on iOS. |
 | `isAppInstalled` | (`appId`: `string`) => `Promise`<`boolean`\> | Check whether the app with the given app ID is installed. |
 | `removeCertificateAuthority` | (`path`: `string`) => `Promise`<`void`\> | Remove the certificate authority with the given path from the trusted CAs on the device. On Android, this works for system CAs, including those pre-installed with the OS. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and removes the CA there. This means that the changes are not persistent across reboots. On iOS, this only works for CAs in the Certificate Trust Store. It does not work for pre-installed OS CAs. The changes are persistent across reboots. Requires the `root` capability on Android, and the `ssh` capability on iOS. |
@@ -155,7 +175,7 @@ Functions that are available for the platforms.
 
 #### Defined in
 
-[index.ts:28](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L28)
+[index.ts:39](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L39)
 
 ___
 
@@ -175,7 +195,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:281](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L281)
+[index.ts:295](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L295)
 
 ___
 
@@ -194,7 +214,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:357](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L357)
+[index.ts:371](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L371)
 
 ___
 
@@ -224,7 +244,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:308](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L308)
+[index.ts:322](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L322)
 
 ___
 
@@ -242,7 +262,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:336](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L336)
+[index.ts:350](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L350)
 
 ___
 
@@ -284,7 +304,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:364](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L364)
+[index.ts:378](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L378)
 
 ## Variables
 
@@ -296,7 +316,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:729](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L729)
+[android.ts:749](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L749)
 
 ___
 
@@ -395,4 +415,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:373](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L373)
+[index.ts:387](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L387)

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,13 +41,13 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:842](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L842)
+[android.ts:860](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L860)
 
 ___
 
 ### AppPath
 
-Ƭ **AppPath**<`Platform`\>: `Platform` extends ``"android"`` ? \`${string}.apk\` \| \`${string}.xapk\` \| \`${string}.apk\`[] : \`${string}.ipa\`
+Ƭ **AppPath**<`Platform`\>: `Platform` extends ``"android"`` ? \`${string}.apk\` \| \`${string}.xapk\` \| \`${string}.apkm\` \| \`${string}.apk\`[] : \`${string}.ipa\`
 
 On Android, the path to a single APK with the `.apk` extension, an array of paths to split APKs with the `.apk`
 extension or the path to an XAPK file with the `.xapk` extension.
@@ -296,7 +296,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:711](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L711)
+[android.ts:729](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L729)
 
 ___
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ appstraction
 ### Type Aliases
 
 - [AndroidPermission](README.md#androidpermission)
+- [AppPath](README.md#apppath)
 - [DeviceAttribute](README.md#deviceattribute)
 - [GetDeviceAttributeOptions](README.md#getdeviceattributeoptions)
 - [IosPermission](README.md#iospermission)
@@ -40,7 +41,28 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:768](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L768)
+[android.ts:836](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L836)
+
+___
+
+### AppPath
+
+Ƭ **AppPath**<`Platform`\>: `Platform` extends ``"android"`` ? \`${string}.apk\` \| \`${string}.xapk\` \| \`${string}.apk\`[] : \`${string}.ipa\`
+
+On Android, the path to a single APK with the `.apk` extension, an array of paths to split APKs with the `.apk`
+extension or the path to an XAPK file with the `.xapk` extension.
+
+On iOS, the path to an IPA file with the `.ipa` extension.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `Platform` | extends [`SupportedPlatform`](README.md#supportedplatform) |
+
+#### Defined in
+
+[index.ts:23](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L23)
 
 ___
 
@@ -58,7 +80,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:332](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L332)
+[index.ts:342](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L342)
 
 ___
 
@@ -77,7 +99,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:338](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L338)
+[index.ts:348](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L348)
 
 ___
 
@@ -118,7 +140,7 @@ Functions that are available for the platforms.
 | `getForegroundAppId` | () => `Promise`<`string` \| `undefined`\> | Get the app ID of the running app that is currently in the foreground. Requires the `frida` capability on iOS. |
 | `getPidForAppId` | (`appId`: `string`) => `Promise`<`number` \| `undefined`\> | Get the PID of the app with the given app ID if it is currently running. Requires the `frida` capability on iOS. |
 | `getPrefs` | (`appId`: `string`) => `Promise`<`Record`<`string`, `unknown`\> \| `undefined`\> | Get the preferences (`SharedPreferences` on Android, `NSUserDefaults` on iOS) of the app with the given app ID. Requires the `frida` capability on Android and iOS. |
-| `installApp` | (`appPath`: `Platform` extends ``"android"`` ? `string` \| `string`[] : `string`) => `Promise`<`void`\> | Install the app at the given path. |
+| `installApp` | (`appPath`: [`AppPath`](README.md#apppath)<`Platform`\>) => `Promise`<`void`\> | Install the app at the given path. |
 | `installCertificateAuthority` | (`path`: `string`) => `Promise`<`void`\> | Install the certificate authority with the given path as a trusted CA on the device. This allows you to intercept and modify traffic from apps on the device. On Android, this installs the CA as a system CA. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and installs the CA there. This means that the changes are not persistent across reboots. On iOS, the CA is installed permanently as a root certificate in the Certificate Trust Store. It persists across reboots.\ **Currently, you need to manually trust any CA at least once on the device, CAs can be added but not automatically marked as trusted (see: https://github.com/tweaselORG/appstraction/issues/44#issuecomment-1466151197).** Requires the `root` capability on Android, and the `ssh` capability on iOS. |
 | `isAppInstalled` | (`appId`: `string`) => `Promise`<`boolean`\> | Check whether the app with the given app ID is installed. |
 | `removeCertificateAuthority` | (`path`: `string`) => `Promise`<`void`\> | Remove the certificate authority with the given path from the trusted CAs on the device. On Android, this works for system CAs, including those pre-installed with the OS. As this is normally not possible on Android 10 and above, it overlays the `/system/etc/security/cacerts` directory with a tmpfs and removes the CA there. This means that the changes are not persistent across reboots. On iOS, this only works for CAs in the Certificate Trust Store. It does not work for pre-installed OS CAs. The changes are persistent across reboots. Requires the `root` capability on Android, and the `ssh` capability on iOS. |
@@ -133,7 +155,7 @@ Functions that are available for the platforms.
 
 #### Defined in
 
-[index.ts:19](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L19)
+[index.ts:28](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L28)
 
 ___
 
@@ -153,7 +175,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:270](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L270)
+[index.ts:280](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L280)
 
 ___
 
@@ -172,7 +194,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:346](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L346)
+[index.ts:356](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L356)
 
 ___
 
@@ -202,7 +224,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:297](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L297)
+[index.ts:307](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L307)
 
 ___
 
@@ -220,7 +242,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:325](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L325)
+[index.ts:335](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L335)
 
 ___
 
@@ -262,7 +284,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:353](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L353)
+[index.ts:363](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L363)
 
 ## Variables
 
@@ -274,7 +296,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:637](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L637)
+[android.ts:705](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L705)
 
 ___
 
@@ -319,7 +341,7 @@ An object with the properties listed above, or `undefined` if the file doesn't e
 
 #### Defined in
 
-[util.ts:57](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L57)
+[util.ts:63](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L63)
 
 ___
 
@@ -341,7 +363,7 @@ Pause for a given duration.
 
 #### Defined in
 
-[util.ts:36](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L36)
+[util.ts:42](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L42)
 
 ___
 
@@ -373,4 +395,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:362](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L362)
+[index.ts:372](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L372)

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:836](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L836)
+[android.ts:842](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L842)
 
 ___
 
@@ -80,7 +80,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:342](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L342)
+[index.ts:343](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L343)
 
 ___
 
@@ -99,7 +99,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:348](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L348)
+[index.ts:349](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L349)
 
 ___
 
@@ -175,7 +175,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:280](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L280)
+[index.ts:281](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L281)
 
 ___
 
@@ -194,7 +194,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:356](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L356)
+[index.ts:357](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L357)
 
 ___
 
@@ -224,7 +224,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:307](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L307)
+[index.ts:308](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L308)
 
 ___
 
@@ -242,7 +242,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:335](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L335)
+[index.ts:336](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L336)
 
 ___
 
@@ -284,7 +284,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:363](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L363)
+[index.ts:364](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L364)
 
 ## Variables
 
@@ -296,7 +296,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:705](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L705)
+[android.ts:711](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L711)
 
 ___
 
@@ -395,4 +395,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:372](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L372)
+[index.ts:373](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L373)

--- a/examples/android-device.ts
+++ b/examples/android-device.ts
@@ -30,7 +30,7 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
 
     console.log('Installed already?', await android.isAppInstalled(appId));
 
-    await android.installApp(`${appPath}/${appId}/*.apk`);
+    await android.installApp(`${appPath}/${appId}/${appId}.apk`);
     await android.setAppBackgroundBatteryUsage(appId, 'unrestricted');
     // First, grant all permissions.
     await android.setAppPermissions(appId);

--- a/examples/android-emulator.ts
+++ b/examples/android-emulator.ts
@@ -35,7 +35,7 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
 
     console.log('Installed already?', await android.isAppInstalled(appId));
 
-    await android.installApp(`${appPath}/${appId}/*.apk`);
+    await android.installApp(`${appPath}/${appId}/${appId}.apk`);
     await android.setAppBackgroundBatteryUsage(appId, 'unrestricted');
     // First, grant all permissions.
     await android.setAppPermissions(appId);

--- a/examples/ios-device.ts
+++ b/examples/ios-device.ts
@@ -38,7 +38,7 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
 
     console.log('Installed already?', await ios.isAppInstalled(appId));
 
-    await ios.installApp(appPath);
+    await ios.installApp(appPath as `${string}.ipa`);
     // First, grant all permissions.
     await ios.setAppPermissions(appId);
     // Then, revoke the camera permission and unset the calendar permission.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "@napi-rs/lzma": "^1.1.2",
         "cross-fetch": "^3.1.5",
         "execa": "^6.1.0",
+        "file-type": "^18.3.0",
         "frida": "^16.0.8",
         "fs-extra": "^11.1.0",
         "ipa-extract-info": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
         "pkijs": "^3.0.14",
         "semver": "^7.3.8",
         "tempy": "^3.0.0",
-        "ts-node": "^10.9.1"
+        "ts-node": "^10.9.1",
+        "yauzl": "^2.10.0"
     },
     "devDependencies": {
         "@baltpeter/eslint-config": "^2.1.2",
@@ -75,6 +76,7 @@
         "@types/plist": "^3.0.2",
         "@types/promise-timeout": "^1.3.0",
         "@types/semver": "^7.3.13",
+        "@types/yauzl": "^2.10.0",
         "@typescript-eslint/eslint-plugin": "5.48.0",
         "eslint": "8.31.0",
         "eslint-plugin-eslint-comments": "3.2.0",

--- a/src/android.ts
+++ b/src/android.ts
@@ -431,7 +431,8 @@ export const androidApi = <RunTarget extends SupportedRunTarget<'android'>>(
 
                 await Promise.all(tmpApks.map((tmpApk) => rm(tmpApk)));
             });
-        } else if (typeof apkPath === 'string' && apkPath.endsWith('.apkm')) {
+        } else if (typeof apkPath === 'string' && (apkPath.endsWith('.apkm') || apkPath.endsWith('.apks'))) {
+            // APKM and APKS are basically the same format now, see https://github.com/tweaselORG/appstraction/issues/66
             if ((await fileTypeFromFile(apkPath))?.mime !== 'application/zip')
                 throw new Error(
                     'Failed to install app: Encrypted apkm files are not supported, use the newer zip format instead.'

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,17 @@ export type AppPath<Platform extends SupportedPlatform> = Platform extends 'andr
     ? `${string}.apk` | `${string}.xapk` | `${string}.apkm` | `${string}.apks` | `${string}.apk`[]
     : `${string}.ipa`;
 
+/** An object that describes how an Android extension file (`.obb`) should be installed on the device. */
+export type ObbInstallSpec = {
+    /** Path to the obb on the host. */
+    obb: `${string}.obb`;
+    /**
+     * Path in relation to `$EXTERNAL_STORAGE` in which to install the obb on the guest. Will be the default app folder
+     * (`$EXTERNAL_STORAGE/Android/obb/<app id>/<file name on host>`) if nothing is specified.
+     */
+    installPath?: `${string}.obb`;
+};
+
 /** Functions that are available for the platforms. */
 export type PlatformApi<
     Platform extends SupportedPlatform,
@@ -72,7 +83,10 @@ export type PlatformApi<
      *   an array of the paths of the split APKs of a single app or the following custom APK bundle formats: `.xapk`,
      *   `.apkm` and `.apks`. Might require the `root` capability to install extension files in XAPKs.
      */
-    installApp: (appPath: AppPath<Platform>) => Promise<void>;
+    installApp: (
+        appPath: AppPath<Platform>,
+        obbPaths?: Platform extends 'android' ? ObbInstallSpec[] : never
+    ) => Promise<void>;
     /**
      * Uninstall the app with the given app ID. Will not fail if the app is not installed.
      *
@@ -266,7 +280,7 @@ export type PlatformApi<
               overlayTmpfs: (directoryPathWithoutLeadingSlash: string) => Promise<void>;
 
               isVpnEnabled: () => Promise<boolean>;
-              installMultiApk: (apks: string[]) => Promise<void>;
+              installMultiApk: (apks: string[]) => Promise<string>;
 
               objectionProcesses: ExecaChildProcess[];
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export type SupportedRunTarget<Platform extends SupportedPlatform> = Platform ex
  * On iOS, the path to an IPA file with the `.ipa` extension.
  */
 export type AppPath<Platform extends SupportedPlatform> = Platform extends 'android'
-    ? `${string}.apk` | `${string}.xapk` | `${string}.apk`[]
+    ? `${string}.apk` | `${string}.xapk` | `${string}.apkm` | `${string}.apk`[]
     : `${string}.ipa`;
 
 /** Functions that are available for the platforms. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,15 @@ export type SupportedRunTarget<Platform extends SupportedPlatform> = Platform ex
     : Platform extends 'ios'
     ? 'device'
     : never;
+/**
+ * On Android, the path to a single APK with the `.apk` extension, an array of paths to split APKs with the `.apk`
+ * extension or the path to an XAPK file with the `.xapk` extension.
+ *
+ * On iOS, the path to an IPA file with the `.ipa` extension.
+ */
+export type AppPath<Platform extends SupportedPlatform> = Platform extends 'android'
+    ? `${string}.apk` | `${string}.xapk` | `${string}.apk`[]
+    : `${string}.ipa`;
 
 /** Functions that are available for the platforms. */
 export type PlatformApi<
@@ -60,9 +69,10 @@ export type PlatformApi<
      * Install the app at the given path.
      *
      * @param appPath Path to the app file (`.ipa` on iOS, `.apk` on Android) to install. On Android, this can also be
-     *   an array of the paths of the split APKs of a single app.
+     *   an array of the paths of the split APKs of a single app or an XAPK file with the extension `.xapk`. Might
+     *   require the `root` capability to install extension files in XAPKs.
      */
-    installApp: (appPath: Platform extends 'android' ? string | string[] : string) => Promise<void>;
+    installApp: (appPath: AppPath<Platform>) => Promise<void>;
     /**
      * Uninstall the app with the given app ID. Will not fail if the app is not installed.
      *

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,6 +266,7 @@ export type PlatformApi<
               overlayTmpfs: (directoryPathWithoutLeadingSlash: string) => Promise<void>;
 
               isVpnEnabled: () => Promise<boolean>;
+              installMultiApk: (apks: string[]) => Promise<void>;
 
               objectionProcesses: ExecaChildProcess[];
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,12 @@ export type SupportedRunTarget<Platform extends SupportedPlatform> = Platform ex
     : never;
 /**
  * On Android, the path to a single APK with the `.apk` extension, an array of paths to split APKs with the `.apk`
- * extension or the path to an XAPK file with the `.xapk` extension.
+ * extension, the path to an XAPK file with the `.xapk` extension or the path to either an `.apkm` or `.apks` file.
  *
  * On iOS, the path to an IPA file with the `.ipa` extension.
  */
 export type AppPath<Platform extends SupportedPlatform> = Platform extends 'android'
-    ? `${string}.apk` | `${string}.xapk` | `${string}.apkm` | `${string}.apk`[]
+    ? `${string}.apk` | `${string}.xapk` | `${string}.apkm` | `${string}.apks` | `${string}.apk`[]
     : `${string}.ipa`;
 
 /** Functions that are available for the platforms. */
@@ -69,8 +69,8 @@ export type PlatformApi<
      * Install the app at the given path.
      *
      * @param appPath Path to the app file (`.ipa` on iOS, `.apk` on Android) to install. On Android, this can also be
-     *   an array of the paths of the split APKs of a single app or an XAPK file with the extension `.xapk`. Might
-     *   require the `root` capability to install extension files in XAPKs.
+     *   an array of the paths of the split APKs of a single app or the following custom APK bundle formats: `.xapk`,
+     *   `.apkm` and `.apks`. Might require the `root` capability to install extension files in XAPKs.
      */
     installApp: (appPath: AppPath<Platform>) => Promise<void>;
     /**

--- a/src/util.ts
+++ b/src/util.ts
@@ -233,11 +233,15 @@ export const getFileFromZip = async (zip: FileHandle, filename: string) =>
  *
  * @returns The file name of the temporary file.
  */
-export const tmpFileFromZipEntry = async (zipFile: ZipFile, entry: Entry, extension?: string) =>
-    new Promise<string>((resolve) => {
+export const tmpFileFromZipEntry = async <Extension extends string>(
+    zipFile: ZipFile,
+    entry: Entry,
+    extension?: Extension
+) =>
+    new Promise<`${string}.${Extension}`>((resolve) => {
         zipFile.openReadStream(entry, (err, stream) => {
             if (err) throw Error;
-            const tmpFile = temporaryFile({ extension });
+            const tmpFile = temporaryFile({ extension }) as `${string}.${Extension}`;
             stream.pipe(createWriteStream(tmpFile).on('finish', () => resolve(tmpFile)));
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,13 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/yauzl@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.0.tgz#b3248295276cf8c6f153ebe6a9aba0c988cb2599"
+  integrity sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@5.48.0":
   version "5.48.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.48.0.tgz#54f8368d080eb384a455f60c2ee044e948a8ce67"

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,6 +945,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tokenizer/token@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
+  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
@@ -2361,6 +2366,15 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-type@^18.3.0:
+  version "18.3.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-18.3.0.tgz#116d4df9120b7f17e973ad5c976b82a40407bd07"
+  integrity sha512-pkPZ5OGIq0TYb37b8bHDLNeQSe1H2KlaQ2ySGpJkkr2KZdaWsO4QhPzHA0mQcsUW2cSqJk+4gM/UyLz/UFbXdQ==
+  dependencies:
+    readable-web-to-node-stream "^3.0.2"
+    strtok3 "^7.0.0"
+    token-types "^5.0.1"
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -2696,7 +2710,7 @@ husky@4.3.7:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -3843,6 +3857,11 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+peek-readable@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-5.0.0.tgz#7ead2aff25dc40458c60347ea76cfdfd63efdfec"
+  integrity sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==
+
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
@@ -4052,6 +4071,15 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readable-stream@^3.6.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@~1.0.17:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
@@ -4071,6 +4099,13 @@ readable-stream@~1.1.9:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
+
+readable-web-to-node-stream@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz#5d52bb5df7b54861fd48d015e93a2cb87b3ee0bb"
+  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
+  dependencies:
+    readable-stream "^3.6.0"
 
 regenerator-runtime@^0.13.7:
   version "0.13.11"
@@ -4511,6 +4546,14 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+strtok3@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-7.0.0.tgz#868c428b4ade64a8fd8fee7364256001c1a4cbe5"
+  integrity sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    peek-readable "^5.0.0"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -4636,6 +4679,14 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+token-types@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-5.0.1.tgz#aa9d9e6b23c420a675e55413b180635b86a093b4"
+  integrity sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    ieee754 "^1.2.1"
 
 tr46@~0.0.3:
   version "0.0.3"


### PR DESCRIPTION
This PR brings support for several unofficial APK bundle formats which are mostly introduced by APK mirror websites:
- `.xapk` by APKPure
- `.apkm` by APKMirror
- `.apks` by SAI

Also, support for separately installing `.obb` extension files in `installApp` has been added.

See also #63, #65, #66.