### PR TITLE
Automatic setup of on-device dependencies for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ Depending on the capabilities and features you want to use, the following packag
 * [Open](http://cydia.saurik.com/package/com.conradkramer.open/) (if you want to launch apps without the `frida` capability), you will need to add a legacy Cydia repository if you are using Sileo: `https://apt.thebigboss.org/repofiles/cydia/`
 * [SSL Kill Switch 2](https://julioverne.github.io/description.html?id=com.julioverne.sslkillswitch2) (for the `certificate-pinning-bypass` capability). Note that this will permanently disable certificate pinning globally, until you uninstall it.
 
-They are installed automatically for each necessary capability if the `ssh` capability is available (meaning all you need to do is set up OpenSSH and appstraction will do the rest).
+They are installed automatically for each necessary capability if the `ssh` capability is available (meaning all you need to do is set up OpenSSH, allowing root login, and appstraction will do the rest).
+
 ## API reference
 
 A full API reference can be found in the [`docs` folder](/docs/README.md).

--- a/README.md
+++ b/README.md
@@ -94,18 +94,18 @@ adb emu avd snapshot save "<snapshot name>" # You can later use this name with t
 
 Installing and uninstalling apps and querying the metadata of an IPA file work without any preparation on a physical iOS device.
 
-For everything else, the iOS device needs to be jailbroken. For iOS 15 and 16, we have tested [palera1n](https://github.com/palera1n/palera1n). For iOS 14, we have previously successfully used [checkra1n](https://checkra.in/) for other projects, but we have not tested appstraction on iOS 14 (as we don't have a device running iOS 14).
+For everything else, the iOS device needs to be jailbroken. For iOS 15 and 16, we have tested [palera1n](https://github.com/palera1n/palera1n) in the **rootful mode**. To jailbreak using palera1n, follow [this guide](https://ios.cfw.guide/installing-palera1n/), but then install the jailbreak with `palera1n -fc` to enable the rootful mode and start the iPhone with `palera1n -f` subsequently.
+For iOS 14, we have previously successfully used [checkra1n](https://checkra.in/) for other projects, but we have not tested appstraction on iOS 14 (as we don't have a device running iOS 14).
 
-Depending on the capabilities and features you want to use, you need to install the following packages from Cydia/Sileo:
+Depending on the capabilities and features you want to use, the following packages from Cydia/Sileo need to be installed:
 
 * [OpenSSH](sileo://package/openssh) (for the `ssh` capability)
 * [SQLite 3.x](sileo://package/sqlite3) (if you want to set app permissions)
 * [Frida](sileo://package/re.frida.server) version 16.0.11 or greater (for the `frida` capability), you will need to [add the Frida repository to Cydia/Sileo](https://frida.re/docs/ios/#with-jailbreak): `https://build.frida.re`
 * [Open](http://cydia.saurik.com/package/com.conradkramer.open/) (if you want to launch apps without the `frida` capability), you will need to add a legacy Cydia repository if you are using Sileo: `https://apt.thebigboss.org/repofiles/cydia/`
-* [SSL Kill Switch 2](https://julioverne.github.io/description.html?id=com.julioverne.sslkillswitch2) (if you want to bypass certificate pinning)
+* [SSL Kill Switch 2](https://julioverne.github.io/description.html?id=com.julioverne.sslkillswitch2) (for the `certificate-pinning-bypass` capability). Note that this will permanently disable certificate pinning globally, until you uninstall it.
 
-You may need to respring after installing the packages.
-
+They are installed automatically for each necessary capability if the `ssh` capability is available (meaning all you need to do is set up OpenSSH and appstraction will do the rest).
 ## API reference
 
 A full API reference can be found in the [`docs` folder](/docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:375](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L375)
+[index.ts:376](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L376)
 
 ___
 
@@ -100,7 +100,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:381](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L381)
+[index.ts:382](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L382)
 
 ___
 
@@ -112,7 +112,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:423](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L423)
+[ios.ts:441](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L441)
 
 ___
 
@@ -199,7 +199,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:313](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L313)
+[index.ts:314](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L314)
 
 ___
 
@@ -218,7 +218,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:389](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L389)
+[index.ts:390](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L390)
 
 ___
 
@@ -248,7 +248,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:340](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L340)
+[index.ts:341](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L341)
 
 ___
 
@@ -266,7 +266,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:368](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L368)
+[index.ts:369](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L369)
 
 ___
 
@@ -308,7 +308,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:396](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L396)
+[index.ts:397](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L397)
 
 ## Variables
 
@@ -332,7 +332,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:406](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L406)
+[ios.ts:424](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L424)
 
 ## Functions
 
@@ -425,4 +425,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:405](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L405)
+[index.ts:406](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L406)

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:374](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L374)
+[index.ts:375](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L375)
 
 ___
 
@@ -100,7 +100,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:380](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L380)
+[index.ts:381](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L381)
 
 ___
 
@@ -112,7 +112,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:386](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L386)
+[ios.ts:423](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L423)
 
 ___
 
@@ -199,7 +199,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:312](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L312)
+[index.ts:313](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L313)
 
 ___
 
@@ -218,7 +218,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:388](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L388)
+[index.ts:389](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L389)
 
 ___
 
@@ -248,7 +248,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:339](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L339)
+[index.ts:340](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L340)
 
 ___
 
@@ -266,7 +266,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:367](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L367)
+[index.ts:368](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L368)
 
 ___
 
@@ -308,7 +308,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:395](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L395)
+[index.ts:396](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L396)
 
 ## Variables
 
@@ -332,7 +332,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:369](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L369)
+[ios.ts:406](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L406)
 
 ## Functions
 
@@ -425,4 +425,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:404](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L404)
+[index.ts:405](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L405)

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:376](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L376)
+[index.ts:382](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L382)
 
 ___
 
@@ -100,7 +100,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:382](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L382)
+[index.ts:388](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L388)
 
 ___
 
@@ -112,7 +112,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:441](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L441)
+[ios.ts:448](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L448)
 
 ___
 
@@ -199,7 +199,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:314](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L314)
+[index.ts:320](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L320)
 
 ___
 
@@ -218,7 +218,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:390](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L390)
+[index.ts:396](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L396)
 
 ___
 
@@ -248,13 +248,13 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:341](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L341)
+[index.ts:347](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L347)
 
 ___
 
 ### SupportedCapability
 
-Ƭ **SupportedCapability**<`Platform`\>: `Platform` extends ``"android"`` ? ``"wireguard"`` \| ``"root"`` \| ``"frida"`` \| ``"certificate-pinning-bypass"`` : `Platform` extends ``"ios"`` ? ``"ssh"`` \| ``"frida"`` : `never`
+Ƭ **SupportedCapability**<`Platform`\>: `Platform` extends ``"android"`` ? ``"wireguard"`` \| ``"root"`` \| ``"frida"`` \| ``"certificate-pinning-bypass"`` : `Platform` extends ``"ios"`` ? ``"ssh"`` \| ``"frida"`` \| ``"certificate-pinning-bypass"`` : `never`
 
 A capability for the `platformApi()` function.
 
@@ -266,7 +266,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:369](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L369)
+[index.ts:375](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L375)
 
 ___
 
@@ -308,7 +308,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:397](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L397)
+[index.ts:403](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L403)
 
 ## Variables
 
@@ -332,7 +332,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:424](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L424)
+[ios.ts:431](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L431)
 
 ## Functions
 
@@ -425,4 +425,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:406](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L406)
+[index.ts:412](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L412)

--- a/examples/ios-device.ts
+++ b/examples/ios-device.ts
@@ -8,7 +8,7 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
     const ios = platformApi({
         platform: 'ios',
         runTarget: 'device',
-        capabilities: ['frida', 'ssh'],
+        capabilities: ['frida', 'ssh', 'certificate-pinning-bypass'],
         targetOptions: {
             ip: process.argv[2] || '0.0.0.0',
         },

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,7 @@ export type PlatformApi<
         : Platform extends 'ios'
         ? {
               ssh: NodeSSH['execCommand'];
+              setupEnvironment: () => Promise<void>;
           }
         : never;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,12 @@ export type PlatformApi<
         : Platform extends 'ios'
         ? {
               ssh: NodeSSH['execCommand'];
+              /**
+               * Will install and set up the necessary dependencies on the device for the chosen capability. This
+               * includes e.g. the frida-server or SSL Kill Switch 2. It will make persistent changes to the device and
+               * add the repositiory servers to the device's sources list. They will be contacted regularly to check for
+               * updates, so be sure of the privacy implications of this.
+               */
               setupEnvironment: () => Promise<void>;
               ensureFrida: () => Promise<void>;
           }
@@ -369,7 +375,7 @@ export type RunTargetOptions<
 export type SupportedCapability<Platform extends SupportedPlatform> = Platform extends 'android'
     ? 'wireguard' | 'root' | 'frida' | 'certificate-pinning-bypass'
     : Platform extends 'ios'
-    ? 'ssh' | 'frida'
+    ? 'ssh' | 'frida' | 'certificate-pinning-bypass'
     : never;
 
 /** A supported attribute for the `getDeviceAttribute()` function, depending on the platform. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -305,6 +305,7 @@ export type PlatformApi<
         ? {
               ssh: NodeSSH['execCommand'];
               setupEnvironment: () => Promise<void>;
+              ensureFrida: () => Promise<void>;
           }
         : never;
 };


### PR DESCRIPTION
This automatically installs missing dependencies on a jailbroken iOS device via `apt`.