### PR TITLE
Fixes #67: Move waiting for the device into a separate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Other functions do need capabilities, though, which you would pass to the `capab
         capabilities: ['frida', 'certificate-pinning-bypass'],
     });
 
+    // Wait until the emulator is completely booted.
+    await android.waitForDevice();
     await android.ensureDevice();
     await android.startApp('<app id>');
     const prefs = await android.getPrefs('<app id>');

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:859](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L859)
+[android.ts:871](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L871)
 
 ___
 
@@ -81,7 +81,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:366](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L366)
+[index.ts:373](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L373)
 
 ___
 
@@ -100,7 +100,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:372](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L372)
+[index.ts:379](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L379)
 
 ___
 
@@ -112,7 +112,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:383](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L383)
+[ios.ts:389](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L389)
 
 ___
 
@@ -175,6 +175,7 @@ Functions that are available for the platforms.
 | `target.platform` | `Platform` | The platform this instance is configured for, i.e. `ios` or `android`. |
 | `target.runTarget` | `RunTarget` | The run target this instance is configured for, i.e. `device` or `emulator`. |
 | `uninstallApp` | (`appId`: `string`) => `Promise`<`void`\> | Uninstall the app with the given app ID. Will not fail if the app is not installed. This also removes any data stored by the app. |
+| `waitForDevice` | (`tries?`: `number`) => `Promise`<`void`\> | Wait until the device or emulator has been connected and has booted up completely. |
 
 #### Defined in
 
@@ -198,7 +199,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:304](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L304)
+[index.ts:311](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L311)
 
 ___
 
@@ -217,7 +218,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:380](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L380)
+[index.ts:387](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L387)
 
 ___
 
@@ -247,7 +248,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:331](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L331)
+[index.ts:338](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L338)
 
 ___
 
@@ -265,7 +266,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:359](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L359)
+[index.ts:366](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L366)
 
 ___
 
@@ -307,7 +308,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:387](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L387)
+[index.ts:394](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L394)
 
 ## Variables
 
@@ -319,7 +320,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:728](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L728)
+[android.ts:740](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L740)
 
 ___
 
@@ -331,7 +332,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:366](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L366)
+[ios.ts:372](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L372)
 
 ## Functions
 
@@ -424,4 +425,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:396](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L396)
+[index.ts:403](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L403)

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:373](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L373)
+[index.ts:374](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L374)
 
 ___
 
@@ -100,7 +100,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:379](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L379)
+[index.ts:380](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L380)
 
 ___
 
@@ -112,7 +112,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:389](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L389)
+[ios.ts:392](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L392)
 
 ___
 
@@ -199,7 +199,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:311](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L311)
+[index.ts:312](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L312)
 
 ___
 
@@ -218,7 +218,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:387](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L387)
+[index.ts:388](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L388)
 
 ___
 
@@ -248,7 +248,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:338](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L338)
+[index.ts:339](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L339)
 
 ___
 
@@ -266,7 +266,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:366](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L366)
+[index.ts:367](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L367)
 
 ___
 
@@ -308,7 +308,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:394](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L394)
+[index.ts:395](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L395)
 
 ## Variables
 
@@ -332,7 +332,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:372](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L372)
+[ios.ts:375](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L375)
 
 ## Functions
 
@@ -425,4 +425,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:403](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L403)
+[index.ts:404](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L404)

--- a/examples/android-emulator.ts
+++ b/examples/android-emulator.ts
@@ -18,6 +18,9 @@ import { parseAppMeta, pause, platformApi } from '../src/index';
     const caCertPath = process.argv[5];
     const wireguardConfigPath = process.argv[5];
 
+    // Wait until the emulator is completely booted.
+    await android.waitForDevice();
+
     await android.ensureDevice();
     await android.resetDevice(snapshotName);
 

--- a/src/android.ts
+++ b/src/android.ts
@@ -65,17 +65,18 @@ export const androidApi = <RunTarget extends SupportedRunTarget<'android'>>(
             const adbIsStarted = await retryCondition(async () => {
                 const { stdout: devBootcomplete } = await adb(
                     ['wait-for-device', 'shell', 'getprop', 'dev.bootcomplete'],
-                    { reject: false }
+                    { reject: false, timeout: 200 }
                 );
                 const { stdout: sysBootCompleted } = await adb(
                     ['wait-for-device', 'shell', 'getprop', 'sys.boot_completed'],
-                    { reject: false }
+                    { reject: false, timeout: 200 }
                 );
                 const { stdout: bootanim } = await adb(['wait-for-device', 'shell', 'getprop', 'init.svc.bootanim'], {
                     reject: false,
+                    timeout: 200,
                 });
                 return devBootcomplete.includes('1') && sysBootCompleted.includes('1') && bootanim.includes('stopped');
-            }, 100);
+            }, 20);
             if (!adbIsStarted) throw new Error('Failed to connect via adb.');
         },
         async ensureFrida() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,13 @@ export type PlatformApi<
     Capability = Capabilities[number]
 > = {
     /**
+     * Wait until the device or emulator has been connected and has booted up completely.
+     *
+     * @param tries The number of times to check if the device is present and booted. One try times out after 6 seconds
+     *   on Android. It defaults to 20.
+     */
+    waitForDevice: Platform extends 'android' ? (tries?: number) => Promise<void> : never;
+    /**
      * Assert that the selected device is connected and ready to be used with the selected capabilities, performing
      * necessary setup steps. This should always be the first function you call.
      *
@@ -280,7 +287,7 @@ export type PlatformApi<
     /** @ignore */
     _internal: Platform extends 'android'
         ? {
-              awaitAdb: () => Promise<void>;
+              hasDeviceBooted: (options?: { waitForDevice?: boolean }) => Promise<boolean>;
               ensureFrida: () => Promise<void>;
               requireRoot: (action: string) => Promise<void>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,10 +45,11 @@ export type PlatformApi<
     /**
      * Wait until the device or emulator has been connected and has booted up completely.
      *
-     * @param tries The number of times to check if the device is present and booted. One try times out after 6 seconds
-     *   on Android. It defaults to 20.
+     * @param tries The number of times to check if the device is present and booted. On Android, one try times out
+     *   after 7 seconds and the default number of tries is 20. On iOS, one try takes about 1 second and the default
+     *   number of tries is 100.
      */
-    waitForDevice: Platform extends 'android' ? (tries?: number) => Promise<void> : never;
+    waitForDevice: (tries?: number) => Promise<void>;
     /**
      * Assert that the selected device is connected and ready to be used with the selected capabilities, performing
      * necessary setup steps. This should always be the first function you call.

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -139,6 +139,7 @@ export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
     },
 
     resetDevice: asyncUnimplemented('resetDevice') as never,
+    waitForDevice: asyncUnimplemented('waitForDevice') as never,
     async ensureDevice() {
         if ((await execa('ideviceinfo', ['-k', 'DeviceName'], { reject: false })).exitCode !== 0)
             throw new Error('You need to connect your device and trust this computer.');


### PR DESCRIPTION
This PR removes the Android-internal `awaitAdb()` function and changes the behavior of `ensureDevice()`. This might be breaking and should be mentioned if this PR is included in a release.