### PR TITLE
Fixes #79: Implement `subject_hash_old` without OpenSSL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Additionally, you will need to [prepare the target device/emulator](#device-prep
 
 If you want to work with physical devices, [some setup may be necessary depending on your system](https://developer.android.com/studio/run/device#setting-up). On Ubuntu, you need to be a member of the `plugdev` group (`sudo usermod -aG plugdev <username>`) and have `udev` rules for your device (`sudo apt install android-sdk-platform-tools-common`). For other distributions, see [android-udev-rules](https://github.com/M0Rf30/android-udev-rules).
 
-You also need `openssl`.
-
 ### Host dependencies for iOS
 
 For iOS, you need [`libimobiledevice`](https://libimobiledevice.org/) and `ideviceinstaller`. The distribution packages are fine, if available. On Windows, you will additionally need the Apple Device Driver and the Apple Application Support service. You can get those by installing iTunes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:876](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L876)
+[android.ts:882](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L882)
 
 ___
 
@@ -112,7 +112,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:397](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L397)
+[ios.ts:393](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L393)
 
 ___
 
@@ -320,7 +320,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:745](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L745)
+[android.ts:751](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L751)
 
 ___
 
@@ -332,7 +332,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:380](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L380)
+[ios.ts:376](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L376)
 
 ## Functions
 
@@ -371,7 +371,7 @@ An object with the properties listed above, or `undefined` if the file doesn't e
 
 #### Defined in
 
-[util.ts:67](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L67)
+[util.ts:68](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L68)
 
 ___
 
@@ -393,7 +393,7 @@ Pause for a given duration.
 
 #### Defined in
 
-[util.ts:44](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L44)
+[util.ts:45](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L45)
 
 ___
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,8 +5,9 @@ import frida from 'frida';
 import { createWriteStream } from 'fs';
 import fs from 'fs-extra';
 import type { FileHandle } from 'fs/promises';
-import { open } from 'fs/promises';
+import { open, readFile } from 'fs/promises';
 import _ipaInfo from 'ipa-extract-info';
+import { Certificate } from 'pkijs';
 import type { Readable } from 'stream';
 import { temporaryFile } from 'tempy';
 import type { Entry, ZipFile } from 'yauzl';
@@ -312,4 +313,14 @@ export type ParametersExceptFirst<F> = F extends (arg0: any, ...rest: infer R) =
 export type XapkManifest = {
     expansions?: { file: string; install_location: string; install_path: string }[];
     split_apks?: { file: string; id: string }[];
+};
+
+export const parsePemCertificateFromFile = async (path: string) => {
+    const certPem = await readFile(path, 'utf8');
+
+    // A PEM certificate is just a base64-encoded DER certificate with a header and footer.
+    const certBase64 = certPem.replace(/(-----(BEGIN|END) CERTIFICATE-----|[\r\n])/g, '');
+    const certDer = Buffer.from(certBase64, 'base64');
+
+    return { cert: Certificate.fromBER(certDer), certPem, certDer };
 };


### PR DESCRIPTION
This is based on #78, which should be merged first.