### PR TITLE
Fix timeout in `waitForDevice()` on iOS

### DIFF
--- a/src/ios.ts
+++ b/src/ios.ts
@@ -220,7 +220,7 @@ Components:" > /etc/apt/sources.list.d/appstraction.sources`);
                 () =>
                     python('pymobiledevice3', ['springboard', 'state', 'get'], {
                         reject: false,
-                        timeout: 1000,
+                        timeout: 10000,
                     }).then(({ stderr, exitCode }) => exitCode === 0 && !stderr.includes('ERROR')),
                 tries
             ))


### PR DESCRIPTION
One second is too short, on my setup it takes ever so slightly longer. On slower systems, we can expect it to take even longer. According to the comment, the timeout was supposed to be 10s anyway.