### PR TITLE
Fixes #43, tweaselORG/cli#24: Use iproxy for ssh

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:404](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L404)
+[index.ts:422](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L422)
 
 ___
 
@@ -101,7 +101,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:410](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L410)
+[index.ts:428](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L428)
 
 ___
 
@@ -113,7 +113,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:472](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L472)
+[ios.ts:493](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L493)
 
 ___
 
@@ -187,7 +187,7 @@ ___
 
 ### PlatformApiOptions
 
-Ƭ **PlatformApiOptions**<`Platform`, `RunTarget`, `Capabilities`\>: { `capabilities`: `Capabilities` ; `platform`: `Platform` ; `runTarget`: `RunTarget`  } & [`RunTargetOptions`](README.md#runtargetoptions)<`Capabilities`\>[`Platform`][`RunTarget`] extends `object` ? { `targetOptions`: [`RunTargetOptions`](README.md#runtargetoptions)<`Capabilities`\>[`Platform`][`RunTarget`]  } : { `targetOptions?`: `Record`<`string`, `never`\>  }
+Ƭ **PlatformApiOptions**<`Platform`, `RunTarget`, `Capabilities`\>: { `capabilities`: `Capabilities` ; `platform`: `Platform` ; `runTarget`: `RunTarget`  } & [`RunTargetOptions`](README.md#runtargetoptions)<`Capabilities`\>[`Platform`][`RunTarget`] extends `object` ? { `targetOptions`: [`RunTargetOptions`](README.md#runtargetoptions)<`Capabilities`\>[`Platform`][`RunTarget`]  } : [`RunTargetOptions`](README.md#runtargetoptions)<`Capabilities`\>[`Platform`][`RunTarget`] extends `object` \| `undefined` ? { `targetOptions?`: [`RunTargetOptions`](README.md#runtargetoptions)<`Capabilities`\>[`Platform`][`RunTarget`]  } : { `targetOptions?`: `Record`<`string`, `never`\>  }
 
 The options for the `platformApi()` function.
 
@@ -201,7 +201,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:339](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L339)
+[index.ts:345](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L345)
 
 ___
 
@@ -220,7 +220,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:418](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L418)
+[index.ts:436](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L436)
 
 ___
 
@@ -244,13 +244,13 @@ The options for a specific platform/run target combination.
 | `android` | { `device`: `unknown` ; `emulator`: `unknown`  } | The options for the Android platform. |
 | `android.device` | `unknown` | The options for the Android physical device run target. |
 | `android.emulator` | `unknown` | The options for the Android emulator run target. |
-| `ios` | { `device`: ``"ssh"`` extends `Capability` ? { `ip?`: `string` ; `port?`: `number` ; `rootPw?`: `string`  } \| `undefined` : `unknown` ; `emulator`: `never`  } | The options for the iOS platform. |
-| `ios.device` | ``"ssh"`` extends `Capability` ? { `ip?`: `string` ; `port?`: `number` ; `rootPw?`: `string`  } \| `undefined` : `unknown` | The options for the iOS physical device run target. |
+| `ios` | { `device`: ``"ssh"`` extends `Capability` ? { `ip?`: `string` ; `password?`: `string` ; `port?`: `number` ; `username?`: ``"mobile"`` \| ``"root"``  } \| `undefined` : `unknown` ; `emulator`: `never`  } | The options for the iOS platform. |
+| `ios.device` | ``"ssh"`` extends `Capability` ? { `ip?`: `string` ; `password?`: `string` ; `port?`: `number` ; `username?`: ``"mobile"`` \| ``"root"``  } \| `undefined` : `unknown` | The options for the iOS physical device run target. |
 | `ios.emulator` | `never` | The options for the iOS emulator run target. |
 
 #### Defined in
 
-[index.ts:366](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L366)
+[index.ts:377](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L377)
 
 ___
 
@@ -268,7 +268,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:397](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L397)
+[index.ts:415](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L415)
 
 ___
 
@@ -310,7 +310,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:425](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L425)
+[index.ts:443](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L443)
 
 ## Variables
 
@@ -334,7 +334,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:455](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L455)
+[ios.ts:476](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L476)
 
 ## Functions
 
@@ -451,4 +451,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:434](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L434)
+[index.ts:452](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L452)

--- a/docs/README.md
+++ b/docs/README.md
@@ -397,7 +397,7 @@ An object with the properties listed above, or `undefined` if the file doesn't e
 
 #### Defined in
 
-[util.ts:71](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L71)
+[util.ts:72](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L72)
 
 ___
 
@@ -419,7 +419,7 @@ Pause for a given duration.
 
 #### Defined in
 
-[util.ts:48](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L48)
+[util.ts:49](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L49)
 
 ___
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:471](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L471)
+[ios.ts:472](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L472)
 
 ___
 
@@ -334,7 +334,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:454](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L454)
+[ios.ts:455](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L455)
 
 ## Functions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:401](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L401)
+[index.ts:404](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L404)
 
 ___
 
@@ -101,7 +101,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:407](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L407)
+[index.ts:410](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L410)
 
 ___
 
@@ -113,7 +113,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:459](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L459)
+[ios.ts:471](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L471)
 
 ___
 
@@ -220,7 +220,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:415](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L415)
+[index.ts:418](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L418)
 
 ___
 
@@ -244,8 +244,8 @@ The options for a specific platform/run target combination.
 | `android` | { `device`: `unknown` ; `emulator`: `unknown`  } | The options for the Android platform. |
 | `android.device` | `unknown` | The options for the Android physical device run target. |
 | `android.emulator` | `unknown` | The options for the Android emulator run target. |
-| `ios` | { `device`: ``"ssh"`` extends `Capability` ? { `ip`: `string` ; `rootPw?`: `string`  } : `unknown` ; `emulator`: `never`  } | The options for the iOS platform. |
-| `ios.device` | ``"ssh"`` extends `Capability` ? { `ip`: `string` ; `rootPw?`: `string`  } : `unknown` | The options for the iOS physical device run target. |
+| `ios` | { `device`: ``"ssh"`` extends `Capability` ? { `ip?`: `string` ; `port?`: `number` ; `rootPw?`: `string`  } \| `undefined` : `unknown` ; `emulator`: `never`  } | The options for the iOS platform. |
+| `ios.device` | ``"ssh"`` extends `Capability` ? { `ip?`: `string` ; `port?`: `number` ; `rootPw?`: `string`  } \| `undefined` : `unknown` | The options for the iOS physical device run target. |
 | `ios.emulator` | `never` | The options for the iOS emulator run target. |
 
 #### Defined in
@@ -268,7 +268,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:394](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L394)
+[index.ts:397](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L397)
 
 ___
 
@@ -310,7 +310,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:422](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L422)
+[index.ts:425](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L425)
 
 ## Variables
 
@@ -334,7 +334,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:442](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L442)
+[ios.ts:454](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L454)
 
 ## Functions
 
@@ -358,7 +358,7 @@ emulators running on the host.
 
 #### Defined in
 
-[util.ts:356](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L356)
+[util.ts:357](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L357)
 
 ___
 
@@ -397,7 +397,7 @@ An object with the properties listed above, or `undefined` if the file doesn't e
 
 #### Defined in
 
-[util.ts:70](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L70)
+[util.ts:71](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L71)
 
 ___
 
@@ -419,7 +419,7 @@ Pause for a given duration.
 
 #### Defined in
 
-[util.ts:47](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L47)
+[util.ts:48](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L48)
 
 ___
 
@@ -451,4 +451,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:431](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L431)
+[index.ts:434](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L434)

--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ An ID of a known permission on iOS.
 
 #### Defined in
 
-[ios.ts:493](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L493)
+[ios.ts:495](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L495)
 
 ___
 
@@ -334,7 +334,7 @@ The IDs of known permissions on iOS.
 
 #### Defined in
 
-[ios.ts:476](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L476)
+[ios.ts:478](https://github.com/tweaselORG/appstraction/blob/main/src/ios.ts#L478)
 
 ## Functions
 
@@ -358,7 +358,7 @@ emulators running on the host.
 
 #### Defined in
 
-[util.ts:357](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L357)
+[util.ts:358](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L358)
 
 ___
 

--- a/examples/ios-device.ts
+++ b/examples/ios-device.ts
@@ -2,22 +2,19 @@
 import { parseAppMeta, pause, platformApi } from '../src/index';
 
 // You can pass the following command line arguments:
-// `npx tsx examples/ios-device.ts <ip> <app path> <CA cert path?> <proxy host?> <proxy port?>`
+// `npx tsx examples/ios-device.ts <app path> <CA cert path?> <proxy host?> <proxy port?>`
 
 (async () => {
     const ios = platformApi({
         platform: 'ios',
         runTarget: 'device',
         capabilities: ['frida', 'ssh', 'certificate-pinning-bypass'],
-        targetOptions: {
-            ip: process.argv[2] || '0.0.0.0',
-        },
     });
 
-    const appPath = process.argv[3] || '/path/to/app-files';
-    const caCertPath = process.argv[4];
-    const proxyHost = process.argv[5];
-    const proxyPort = process.argv[6];
+    const appPath = process.argv[2] || '/path/to/app-files';
+    const caCertPath = process.argv[3];
+    const proxyHost = process.argv[4];
+    const proxyPort = process.argv[5];
 
     await ios.ensureDevice();
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "ipa-extract-info": "^1.2.6",
         "node-ssh": "^13.1.0",
         "p-retry": "^5.1.2",
+        "p-timeout": "^6.1.2",
         "pkijs": "^3.0.14",
         "semver": "^7.3.8",
         "tempy": "^3.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -380,12 +380,15 @@ export type RunTargetOptions<
         emulator: never;
         /** The options for the iOS physical device run target. */
         device: 'ssh' extends Capability
-            ? {
-                  /** The password of the root user on the device, defaults to `alpine` if not set. */
-                  rootPw?: string;
-                  /** The device's IP address. */
-                  ip: string;
-              }
+            ?
+                  | {
+                        /** The password of the root user on the device, defaults to `alpine` if not set. */
+                        rootPw?: string;
+                        /** The device's IP address. */
+                        ip?: string;
+                        port?: number;
+                    }
+                  | undefined
             : unknown;
     };
 };

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -178,7 +178,9 @@ export const iosApi = <RunTarget extends SupportedRunTarget<'ios'>>(
                 neededPackages.push('com.julioverne.sslkillswitch2');
 
             const { stdout: packageList } = await this.ssh(['apt', 'list', '--installed']);
-            const packagesToInstall = neededPackages.filter((p) => !packageList.includes(p));
+            const packagesToInstall = neededPackages.filter(
+                (p) => !packageList.split('\n').some((l) => l.startsWith(`${p}/`))
+            );
             if (packagesToInstall.length > 0) {
                 // https://github.com/tweaselORG/appstraction/issues/59
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -332,7 +332,7 @@ export const parsePemCertificateFromFile = async (path: string) => {
 
 const NO_ESCAPE_REGEXP = /^[\w.-]+$/;
 const DOUBLE_QUOTES_REGEXP = /"/g;
-const IS_QUOTED_REGEXP = /^".*"$/;
+const IS_QUOTED_REGEXP = /^".*"$/s;
 
 export const escapeArg = (arg: string) => {
     if (typeof arg !== 'string' || NO_ESCAPE_REGEXP.test(arg)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4484,6 +4484,11 @@ p-retry@^5.1.2:
     "@types/retry" "0.12.1"
     retry "^0.13.1"
 
+p-timeout@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-6.1.2.tgz#22b8d8a78abf5e103030211c5fc6dee1166a6aa5"
+  integrity sha512-UbD77BuZ9Bc9aABo74gfXhNvzC9Tx7SxtHSh1fxvx3jTLLYvmVhiQZZrJzqqU0jKbN32kb5VOKiLEQI/3bIjgQ==
+
 parcel@2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/parcel/-/parcel-2.8.2.tgz#6539c0a435b14e5829d09254b0394dcfbc0b0ba5"


### PR DESCRIPTION
This enables SSH connections via USB and minimal setup after the jailbreak. Running (rooted) SSH commands via the `mobile` user is also supported via this PR. I tested it on freshly jailbroken iOS 15 and 16.