### PR TITLE
Fixes tweaselORG/docs.tweasel.org#3: Install clang bindings using pip

### DIFF
--- a/scripts/common/python.js
+++ b/scripts/common/python.js
@@ -3,6 +3,7 @@ export const venvOptions = {
     pythonVersion: '~3.11',
     requirements: [
         { name: 'pip', version: '~=23.1' },
+        { name: 'libclang', version: '~=16.0' },
         { name: 'frida-tools', version: '~=12.1' },
         { name: 'pymobiledevice3', version: '~=1.42' },
     ],


### PR DESCRIPTION
Uses https://pypi.org/project/libclang/ to install clang binding, so that users don’t need a complete build env to install all dependencies. I tested it on a fresh Ubuntu.