### PR TITLE
Download WireGuard APK from their website (instead of F-Droid)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:422](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L422)
+[index.ts:425](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L425)
 
 ___
 
@@ -101,7 +101,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:428](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L428)
+[index.ts:431](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L431)
 
 ___
 
@@ -156,7 +156,7 @@ Functions that are available for the platforms.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `clearStuckModals` | `Platform` extends ``"android"`` ? () => `Promise`<`void`\> : `never` | Clear any potential stuck modals by pressing the back button followed by the home button. This is currently broken on iOS (see https://github.com/tweaselORG/appstraction/issues/12). Requires the `ssh` capability on iOS. |
-| `ensureDevice` | () => `Promise`<`void`\> | Assert that the selected device is connected and ready to be used with the selected capabilities, performing necessary setup steps. This should always be the first function you call. Note that depending on the capabilities you set, the setup steps may make permanent changes to your device. |
+| `ensureDevice` | () => `Promise`<`void`\> | Assert that the selected device is connected and ready to be used with the selected capabilities, performing necessary setup steps. This should always be the first function you call. Note that depending on the capabilities you set, the setup steps may make permanent changes to your device. For Android, you can set the url to the WireGuard APK which should be installed in the `WIREGUARD_APK_URL` environment variable. Note that it is only used if WireGuard isn’t installed already. |
 | `getDeviceAttribute` | <Attribute\>(`attribute`: `Attribute`, ...`options`: `Attribute` extends keyof [`GetDeviceAttributeOptions`](README.md#getdeviceattributeoptions) ? [options: GetDeviceAttributeOptions[Attribute]] : [options?: undefined]) => `Promise`<`string`\> | Get the value of the given attribute of the device. Requires the `frida` capability on iOS. |
 | `getForegroundAppId` | () => `Promise`<`string` \| `undefined`\> | Get the app ID of the running app that is currently in the foreground. Requires the `frida` capability on iOS. |
 | `getPidForAppId` | (`appId`: `string`) => `Promise`<`number` \| `undefined`\> | Get the PID of the app with the given app ID if it is currently running. Requires the `frida` capability on iOS. |
@@ -201,7 +201,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:345](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L345)
+[index.ts:348](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L348)
 
 ___
 
@@ -220,7 +220,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:436](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L436)
+[index.ts:439](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L439)
 
 ___
 
@@ -250,7 +250,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:377](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L377)
+[index.ts:380](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L380)
 
 ___
 
@@ -268,7 +268,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:415](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L415)
+[index.ts:418](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L418)
 
 ___
 
@@ -310,7 +310,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:443](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L443)
+[index.ts:446](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L446)
 
 ## Variables
 
@@ -451,4 +451,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:452](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L452)
+[index.ts:455](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L455)

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:967](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L967)
+[android.ts:954](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L954)
 
 ___
 
@@ -322,7 +322,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:836](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L836)
+[android.ts:823](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L823)
 
 ___
 

--- a/src/android.ts
+++ b/src/android.ts
@@ -369,22 +369,9 @@ export const androidApi = <RunTarget extends SupportedRunTarget<'android'>>(
             // Install app if necessary.
             if (!(await this.isAppInstalled('com.wireguard.android'))) {
                 try {
-                    const fdroidVersionCode = await fetch('https://f-droid.org/api/v1/packages/com.wireguard.android')
-                        .then((res) => res.json())
-                        .then((fdroidMeta) => {
-                            if (
-                                fdroidMeta.packages.some(
-                                    (p: { versionCode: number }) => p.versionCode === fdroidMeta.suggestedVersionCode
-                                )
-                            )
-                                return fdroidMeta.suggestedVersionCode;
-
-                            return fdroidMeta.packages.sort(
-                                (a: { versionCode: number }, b: { versionCode: number }) =>
-                                    b.versionCode - a.versionCode
-                            )[0].versionCode;
-                        });
-                    const apkUrl = `https://f-droid.org/repo/com.wireguard.android_${fdroidVersionCode}.apk`;
+                    const apkUrl =
+                        process.env['WIREGUARD_APK_URL'] ||
+                        'https://download.wireguard.com/android-client/com.wireguard.android-1.0.20231018.apk';
 
                     // `adb` complains if we try to install a file with the wrong extension.
                     const apkTmpPath = temporaryFile({ extension: 'apk' }) as `${string}.apk`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,9 @@ export type PlatformApi<
      * necessary setup steps. This should always be the first function you call.
      *
      * Note that depending on the capabilities you set, the setup steps may make permanent changes to your device.
+     *
+     * For Android, you can set the url to the WireGuard APK which should be installed in the `WIREGUARD_APK_URL`
+     * environment variable. Note that it is only used if WireGuard isn’t installed already.
      */
     ensureDevice: () => Promise<void>;
     /**


### PR DESCRIPTION
WireGuard was removed from f-droid where we got it from (https://forum.f-droid.org/t/where-is-wireguard/24600/2), but since then they published the APK on their own website (https://www.wireguard.com/install/#android-play-store-direct-apk-file). We now use this website to download the WireGuard APK.

We also fixed the installed WireGuard app version with this change. If user want to install other version or from other sources, they can do so by setting the `WIREGUARD_APK_URL` environment variable to a URL they want appstraction to install WireGuard from (or just install it manually).