### PR TITLE
parseAppMeta(): Expose return type, include platform and MD5

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ Metadata about an app, as returned by [parseAppMeta](README.md#parseappmeta).
 | :------ | :------ | :------ |
 | `architectures` | (``"arm64"`` \| ``"arm"`` \| ``"x86"`` \| ``"x86_64"`` \| ``"mips"`` \| ``"mips64"``)[] | A list of the architectures that the app supports. The identifiers for the architectures are normalized across Android and iOS. On Android, this will be empty for apps that don't have native code. |
 | `id` | `string` | The app/bundle ID. |
+| `md5?` | `string` | The MD5 hash of the app's package file. In the case of split APKs on Android, this will be the hash of the main APK. In the case of custom APK bundle formats (`.xapk`, `.apkm` and `.apks`), this will be the hash of the entire bundle. **Be careful when interpreting this value.** App stores can deliver different distributions of the exact same app. For example, apps downloaded from the App Store on iOS include the user's Apple ID, thus leading to different hashes even if different users download the very same version of the same app. |
 | `name?` | `string` | The app's display name. |
 | `platform` | [`SupportedPlatform`](README.md#supportedplatform) | The platform the app is for. |
 | `version?` | `string` | The app's human-readable version. |
@@ -106,7 +107,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:452](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L452)
+[index.ts:463](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L463)
 
 ___
 
@@ -125,7 +126,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:456](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L456)
+[index.ts:467](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L467)
 
 ___
 
@@ -205,7 +206,7 @@ Functions that are available for the platforms.
 
 #### Defined in
 
-[index.ts:61](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L61)
+[index.ts:72](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L72)
 
 ___
 
@@ -225,7 +226,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:375](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L375)
+[index.ts:386](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L386)
 
 ___
 
@@ -244,7 +245,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:464](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L464)
+[index.ts:475](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L475)
 
 ___
 
@@ -274,7 +275,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:407](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L407)
+[index.ts:418](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L418)
 
 ___
 
@@ -292,7 +293,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:445](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L445)
+[index.ts:456](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L456)
 
 ___
 
@@ -334,7 +335,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:471](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L471)
+[index.ts:482](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L482)
 
 ## Variables
 
@@ -382,7 +383,7 @@ emulators running on the host.
 
 #### Defined in
 
-[util.ts:360](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L360)
+[util.ts:390](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L390)
 
 ___
 
@@ -419,7 +420,7 @@ An object containing the parsed metadata, or `undefined` if the file doesn't exi
 
 #### Defined in
 
-[util.ts:68](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L68)
+[util.ts:69](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L69)
 
 ___
 
@@ -441,7 +442,7 @@ Pause for a given duration.
 
 #### Defined in
 
-[util.ts:49](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L49)
+[util.ts:50](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L50)
 
 ___
 
@@ -473,4 +474,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:480](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L480)
+[index.ts:491](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L491)

--- a/docs/README.md
+++ b/docs/README.md
@@ -381,7 +381,7 @@ emulators running on the host.
 
 #### Defined in
 
-[util.ts:342](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L342)
+[util.ts:358](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L358)
 
 ___
 
@@ -390,6 +390,11 @@ ___
 ▸ **parseAppMeta**<`Platform`\>(`appPath`, `_platform?`): `Promise`<`undefined` \| [`AppMeta`](README.md#appmeta)\>
 
 Get metadata about the app at the given path.
+
+**`Remarks`**
+
+If you pass multiple APKs from different apps, no error will be raised. The metadata for the first app will be
+returned.
 
 #### Type parameters
 
@@ -413,7 +418,7 @@ An object containing the parsed metadata, or `undefined` if the file doesn't exi
 
 #### Defined in
 
-[util.ts:65](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L65)
+[util.ts:68](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L68)
 
 ___
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@ Metadata about an app, as returned by [parseAppMeta](README.md#parseappmeta).
 | `architectures` | (``"arm64"`` \| ``"arm"`` \| ``"x86"`` \| ``"x86_64"`` \| ``"mips"`` \| ``"mips64"``)[] | A list of the architectures that the app supports. The identifiers for the architectures are normalized across Android and iOS. On Android, this will be empty for apps that don't have native code. |
 | `id` | `string` | The app/bundle ID. |
 | `name?` | `string` | The app's display name. |
+| `platform` | [`SupportedPlatform`](README.md#supportedplatform) | The platform the app is for. |
 | `version?` | `string` | The app's human-readable version. |
 | `versionCode?` | `string` | The app's version code. |
 
@@ -105,7 +106,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:450](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L450)
+[index.ts:452](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L452)
 
 ___
 
@@ -124,7 +125,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:454](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L454)
+[index.ts:456](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L456)
 
 ___
 
@@ -204,7 +205,7 @@ Functions that are available for the platforms.
 
 #### Defined in
 
-[index.ts:59](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L59)
+[index.ts:61](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L61)
 
 ___
 
@@ -224,7 +225,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:373](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L373)
+[index.ts:375](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L375)
 
 ___
 
@@ -243,7 +244,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:462](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L462)
+[index.ts:464](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L464)
 
 ___
 
@@ -273,7 +274,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:405](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L405)
+[index.ts:407](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L407)
 
 ___
 
@@ -291,7 +292,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:443](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L443)
+[index.ts:445](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L445)
 
 ___
 
@@ -333,7 +334,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:469](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L469)
+[index.ts:471](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L471)
 
 ## Variables
 
@@ -381,7 +382,7 @@ emulators running on the host.
 
 #### Defined in
 
-[util.ts:358](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L358)
+[util.ts:360](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L360)
 
 ___
 
@@ -472,4 +473,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:478](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L478)
+[index.ts:480](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L480)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ appstraction
 ### Type Aliases
 
 - [AndroidPermission](README.md#androidpermission)
+- [AppMeta](README.md#appmeta)
 - [AppPath](README.md#apppath)
 - [DeviceAttribute](README.md#deviceattribute)
 - [GetDeviceAttributeOptions](README.md#getdeviceattributeoptions)
@@ -47,6 +48,28 @@ An ID of a known permission on Android.
 
 ___
 
+### AppMeta
+
+Ƭ **AppMeta**: `Object`
+
+Metadata about an app, as returned by [parseAppMeta](README.md#parseappmeta).
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `architectures` | (``"arm64"`` \| ``"arm"`` \| ``"x86"`` \| ``"x86_64"`` \| ``"mips"`` \| ``"mips64"``)[] | A list of the architectures that the app supports. The identifiers for the architectures are normalized across Android and iOS. On Android, this will be empty for apps that don't have native code. |
+| `id` | `string` | The app/bundle ID. |
+| `name?` | `string` | The app's display name. |
+| `version?` | `string` | The app's human-readable version. |
+| `versionCode?` | `string` | The app's version code. |
+
+#### Defined in
+
+[index.ts:40](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L40)
+
+___
+
 ### AppPath
 
 Ƭ **AppPath**<`Platform`\>: `Platform` extends ``"android"`` ? \`${string}.apk\` \| \`${string}.xapk\` \| \`${string}.apkm\` \| \`${string}.apks\` \| \`${string}.apk\`[] : \`${string}.ipa\`
@@ -82,7 +105,7 @@ A supported attribute for the `getDeviceAttribute()` function, depending on the 
 
 #### Defined in
 
-[index.ts:431](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L431)
+[index.ts:450](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L450)
 
 ___
 
@@ -101,7 +124,7 @@ The options for each attribute available through the `getDeviceAttribute()` func
 
 #### Defined in
 
-[index.ts:435](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L435)
+[index.ts:454](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L454)
 
 ___
 
@@ -181,7 +204,7 @@ Functions that are available for the platforms.
 
 #### Defined in
 
-[index.ts:40](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L40)
+[index.ts:59](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L59)
 
 ___
 
@@ -201,7 +224,7 @@ The options for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:354](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L354)
+[index.ts:373](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L373)
 
 ___
 
@@ -220,7 +243,7 @@ Connection details for a proxy.
 
 #### Defined in
 
-[index.ts:443](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L443)
+[index.ts:462](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L462)
 
 ___
 
@@ -250,7 +273,7 @@ The options for a specific platform/run target combination.
 
 #### Defined in
 
-[index.ts:386](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L386)
+[index.ts:405](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L405)
 
 ___
 
@@ -268,7 +291,7 @@ A capability for the `platformApi()` function.
 
 #### Defined in
 
-[index.ts:424](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L424)
+[index.ts:443](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L443)
 
 ___
 
@@ -310,7 +333,7 @@ Configuration string for WireGuard.
 
 #### Defined in
 
-[index.ts:450](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L450)
+[index.ts:469](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L469)
 
 ## Variables
 
@@ -358,22 +381,15 @@ emulators running on the host.
 
 #### Defined in
 
-[util.ts:358](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L358)
+[util.ts:342](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L342)
 
 ___
 
 ### parseAppMeta
 
-▸ **parseAppMeta**<`Platform`\>(`appPath`, `_platform?`): `Promise`<`undefined` \| { `architectures`: (``"arm64"`` \| ``"arm"`` \| ``"x86"`` \| ``"x86_64"`` \| ``"mips"`` \| ``"mips64"``)[] ; `id`: `string` ; `name?`: `string` ; `version?`: `string` ; `versionCode?`: `string`  }\>
+▸ **parseAppMeta**<`Platform`\>(`appPath`, `_platform?`): `Promise`<`undefined` \| [`AppMeta`](README.md#appmeta)\>
 
-Get metadata about the app at the given path. This includes the following properties:
-
-- `id`: The app's ID.
-- `name`: The app's display name.
-- `version`: The app's human-readable version.
-- `versionCode`: The app's version code.
-- `architectures`: The architectures the device needs to support to run the app. On Android, this will be empty for
-  apps that don't have native code.
+Get metadata about the app at the given path.
 
 #### Type parameters
 
@@ -390,14 +406,14 @@ Get metadata about the app at the given path. This includes the following proper
 
 #### Returns
 
-`Promise`<`undefined` \| { `architectures`: (``"arm64"`` \| ``"arm"`` \| ``"x86"`` \| ``"x86_64"`` \| ``"mips"`` \| ``"mips64"``)[] ; `id`: `string` ; `name?`: `string` ; `version?`: `string` ; `versionCode?`: `string`  }\>
+`Promise`<`undefined` \| [`AppMeta`](README.md#appmeta)\>
 
-An object with the properties listed above, or `undefined` if the file doesn't exist or is not a valid app
-  for the platform.
+An object containing the parsed metadata, or `undefined` if the file doesn't exist or is not a valid app for
+  the platform.
 
 #### Defined in
 
-[util.ts:72](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L72)
+[util.ts:65](https://github.com/tweaselORG/appstraction/blob/main/src/util.ts#L65)
 
 ___
 
@@ -451,4 +467,4 @@ The API object for the given platform and run target.
 
 #### Defined in
 
-[index.ts:459](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L459)
+[index.ts:478](https://github.com/tweaselORG/appstraction/blob/main/src/index.ts#L478)

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "file-type": "^18.3.0",
         "frida": "^16.0.8",
         "fs-extra": "^11.1.0",
+        "hasha": "^6.0.0",
         "ipa-extract-info": "^1.2.6",
         "node-ssh": "^13.1.0",
         "p-retry": "^5.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,8 @@ export type ObbInstallSpec = {
 
 /** Metadata about an app, as returned by {@link parseAppMeta}. */
 export type AppMeta = {
+    /** The platform the app is for. */
+    platform: SupportedPlatform;
     /** The app/bundle ID. */
     id: string;
     /** The app's display name. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,25 @@ export type ObbInstallSpec = {
     installPath?: `${string}.obb`;
 };
 
+/** Metadata about an app, as returned by {@link parseAppMeta}. */
+export type AppMeta = {
+    /** The app/bundle ID. */
+    id: string;
+    /** The app's display name. */
+    name?: string;
+    /** The app's human-readable version. */
+    version?: string;
+    /** The app's version code. */
+    versionCode?: string;
+    /**
+     * A list of the architectures that the app supports. The identifiers for the architectures are normalized across
+     * Android and iOS.
+     *
+     * On Android, this will be empty for apps that don't have native code.
+     */
+    architectures: ('arm64' | 'arm' | 'x86' | 'x86_64' | 'mips' | 'mips64')[];
+};
+
 /** Functions that are available for the platforms. */
 export type PlatformApi<
     Platform extends SupportedPlatform,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,17 @@ export type AppMeta = {
      * On Android, this will be empty for apps that don't have native code.
      */
     architectures: ('arm64' | 'arm' | 'x86' | 'x86_64' | 'mips' | 'mips64')[];
+    /**
+     * The MD5 hash of the app's package file.
+     *
+     * In the case of split APKs on Android, this will be the hash of the main APK. In the case of custom APK bundle
+     * formats (`.xapk`, `.apkm` and `.apks`), this will be the hash of the entire bundle.
+     *
+     * **Be careful when interpreting this value.** App stores can deliver different distributions of the exact same
+     * app. For example, apps downloaded from the App Store on iOS include the user's Apple ID, thus leading to
+     * different hashes even if different users download the very same version of the same app.
+     */
+    md5?: string;
 };
 
 /** Functions that are available for the platforms. */

--- a/src/util.ts
+++ b/src/util.ts
@@ -103,6 +103,7 @@ export const parseAppMeta = async <Platform extends SupportedPlatform>(
             } as const;
 
             return {
+                platform,
                 id,
                 name: stdout.match(/application-label:'(.*?)'/)?.[1],
                 version: stdout.match(/versionName='([^']+?)'/)?.[1],
@@ -111,7 +112,7 @@ export const parseAppMeta = async <Platform extends SupportedPlatform>(
                     Object.keys(architectureNativeCodeMap) as (keyof typeof architectureNativeCodeMap)[]
                 ).filter((a) => nativeCode.includes(architectureNativeCodeMap[a])),
                 ...(options.includeIsSplit && { isSplit: stdout.includes("split='") }),
-            };
+            } as const;
         };
 
         if (Array.isArray(appPath)) {
@@ -174,6 +175,7 @@ export const parseAppMeta = async <Platform extends SupportedPlatform>(
         ).filter((a) => (meta.info['UIRequiredDeviceCapabilities'] as string[]).includes(architectureCapabilityMap[a]));
 
         return {
+            platform,
             id,
             // See https://stackoverflow.com/a/15423880 for why we use `CFBundleDisplayName` instead of `CFBundleName`.
             name: meta.info['CFBundleDisplayName'] as string | undefined,

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,7 +16,7 @@ import { temporaryFile } from 'tempy';
 import type { Entry, ZipFile } from 'yauzl';
 import { fromFd } from 'yauzl';
 import { venvOptions } from '../scripts/common/python';
-import type { AppPath, SupportedPlatform } from './index';
+import type { AppMeta, AppPath, SupportedPlatform } from './index';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const asyncNop = async () => {};
@@ -52,36 +52,20 @@ export const pause = (durationInMs: number) =>
     });
 
 /**
- * Get metadata about the app at the given path. This includes the following properties:
- *
- * - `id`: The app's ID.
- * - `name`: The app's display name.
- * - `version`: The app's human-readable version.
- * - `versionCode`: The app's version code.
- * - `architectures`: The architectures the device needs to support to run the app. On Android, this will be empty for
- *   apps that don't have native code.
+ * Get metadata about the app at the given path.
  *
  * @param appPath Path to the app file (`.ipa` on iOS, `.apk` on Android) to get the metadata of. On Android, this can
  *   also be an array of the paths of the split APKs of a single app or the following custom APK bundle formats:
  *   `.xapk`, `.apkm` and `.apks`.
  * @param platform The platform the app file is for. If not provided, it will be inferred from the file extension.
  *
- * @returns An object with the properties listed above, or `undefined` if the file doesn't exist or is not a valid app
- *   for the platform.
+ * @returns An object containing the parsed metadata, or `undefined` if the file doesn't exist or is not a valid app for
+ *   the platform.
  */
 export const parseAppMeta = async <Platform extends SupportedPlatform>(
     appPath: AppPath<Platform>,
     _platform?: Platform
-): Promise<
-    | {
-          id: string;
-          name?: string;
-          version?: string;
-          versionCode?: string;
-          architectures: ('arm64' | 'arm' | 'x86' | 'x86_64' | 'mips' | 'mips64')[];
-      }
-    | undefined
-> => {
+): Promise<AppMeta | undefined> => {
     const platform = _platform ?? (typeof appPath === 'string' && appPath.endsWith('.ipa') ? 'ios' : 'android');
 
     if (platform === 'android') {

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,6 +54,9 @@ export const pause = (durationInMs: number) =>
 /**
  * Get metadata about the app at the given path.
  *
+ * @remarks
+ * If you pass multiple APKs from different apps, no error will be raised. The metadata for the first app will be
+ * returned.
  * @param appPath Path to the app file (`.ipa` on iOS, `.apk` on Android) to get the metadata of. On Android, this can
  *   also be an array of the paths of the split APKs of a single app or the following custom APK bundle formats:
  *   `.xapk`, `.apkm` and `.apks`.
@@ -69,7 +72,11 @@ export const parseAppMeta = async <Platform extends SupportedPlatform>(
     const platform = _platform ?? (typeof appPath === 'string' && appPath.endsWith('.ipa') ? 'ios' : 'android');
 
     if (platform === 'android') {
-        const parseApk = async (apkPath: string) => {
+        /**
+         * @param options - `includeIsSplit`: The `isSplit` property is only used internally in this function if
+         *   multiple APKs are passed. It should not be exposed to the end user.
+         */
+        const parseApk = async (apkPath: string, options: { includeIsSplit?: boolean } = {}) => {
             // This sometimes fails with `AndroidManifest.xml:42: error: ERROR getting 'android:icon' attribute: attribute
             // value reference does not exist` but still has the correct version in the output.
             const { stdout } = await runAndroidDevTool('aapt', ['dump', 'badging', apkPath], { reject: false });
@@ -103,14 +110,23 @@ export const parseAppMeta = async <Platform extends SupportedPlatform>(
                 architectures: (
                     Object.keys(architectureNativeCodeMap) as (keyof typeof architectureNativeCodeMap)[]
                 ).filter((a) => nativeCode.includes(architectureNativeCodeMap[a])),
-                isSplit: stdout.includes("split='"),
+                ...(options.includeIsSplit && { isSplit: stdout.includes("split='") }),
             };
         };
 
         if (Array.isArray(appPath)) {
             for (const apkPath of appPath) {
-                const meta = await parseApk(apkPath);
-                if (!meta?.isSplit) return meta;
+                const _meta = await parseApk(apkPath, { includeIsSplit: true });
+
+                // The actual metadata is in the main APK, which has `isSplit: false`.
+                if (_meta?.isSplit === false) {
+                    // We only use the `isSplit` flag to identify the main APK, so we remove it here. Including
+                    // `isSplit: false` would be misleading, since we are returning the metadata for the "whole" app,
+                    // which may well consist of a main APK plus split APKs.
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const { isSplit, ...meta } = _meta;
+                    return meta;
+                }
             }
 
             return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3248,6 +3248,14 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hasha@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-6.0.0.tgz#bdf1231ae40b406121c09c13705e5b38c1bb607c"
+  integrity sha512-MLydoyGp9QJcjlhE5lsLHXYpWayjjWqkavzju2ZWD2tYa1CgmML1K1gWAu22BLFa2eZ0OfvJ/DlfoVjaD54U2Q==
+  dependencies:
+    is-stream "^3.0.0"
+    type-fest "^4.7.1"
+
 htmlnano@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-2.0.3.tgz#50ee639ed63357d4a6c01309f52a35892e4edc2e"
@@ -5627,6 +5635,11 @@ type-fest@^3.5.6:
   version "3.5.6"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.5.6.tgz#f8f3a630c185fb5d66ca6950c7cbc2893deb6b84"
   integrity sha512-6bd2bflx8ed7c99tc6zSTIzHr1/QG29bQoK4Qh8MYGnlPbODUzGxklLShjwc/xWQQFHgIci+y5Arv7Rbb0LjXw==
+
+type-fest@^4.7.1:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.17.0.tgz#4c1b2c2852d2a40ba8c0236d3afc6fc68229e5bf"
+  integrity sha512-9flrz1zkfLRH3jO3bLflmTxryzKMxVa7841VeMgBaNQGY6vH4RCcpN/sQLB7mQQYh1GZ5utT2deypMuCy4yicw==
 
 typed-array-length@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This is based on #130, which needs to be merged first.

**This should be squashed.**