### PR TITLE
Fixes #138: Set correct file and SE Linux permissions on CA certificates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ An ID of a known permission on Android.
 
 #### Defined in
 
-[android.ts:1102](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L1102)
+[android.ts:1108](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L1108)
 
 ___
 
@@ -394,7 +394,7 @@ The IDs of known permissions on Android.
 
 #### Defined in
 
-[android.ts:971](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L971)
+[android.ts:977](https://github.com/tweaselORG/appstraction/blob/main/src/android.ts#L977)
 
 ___
 

--- a/src/android.ts
+++ b/src/android.ts
@@ -7,7 +7,7 @@ import { fileTypeFromFile } from 'file-type';
 import frida from 'frida';
 import { open, readFile, rm, writeFile } from 'fs/promises';
 import pRetry from 'p-retry';
-import { basename, dirname } from 'path';
+import { basename, dirname, join } from 'path';
 import { major as semverMajor, minVersion as semverMinVersion } from 'semver';
 import { temporaryFile } from 'tempy';
 import type {
@@ -786,15 +786,21 @@ export const androidApi = <RunTarget extends SupportedRunTarget<'android'>>(
 
         if (await this._internal.hasCertificateAuthority(certFilename)) return;
 
-        const { adbRootPush } = await this._internal.requireRoot('installCertificateAuthority');
+        const { adbRootShell, adbRootPush } = await this._internal.requireRoot('installCertificateAuthority');
 
         // Since Android 10, we cannot write to `/system` anymore, even if we are root, see:
         // https://github.com/tweaselORG/meta/issues/18#issuecomment-1437057934
         // Thanks to HTTP Toolkit for the idea to use a tmpfs as a workaround:
         // https://github.com/httptoolkit/httptoolkit-server/blob/9658bef164fb5cfce13b2c4b1bedacc158767f57/src/interceptors/android/adb-commands.ts#L228-L230
-        await this._internal.overlayTmpfs('/system/etc/security/cacerts');
+        const systemCertPath = '/system/etc/security/cacerts';
+        await this._internal.overlayTmpfs(systemCertPath);
 
         await adbRootPush(path, `/system/etc/security/cacerts/${certFilename}`);
+
+        await adbRootShell([`chown root:root ${join(systemCertPath, '*')}`]);
+        await adbRootShell([`chmod 655 ${join(systemCertPath, '*')}`]);
+        await adbRootShell([`chcon u:object_r:system_file:s0 ${join(systemCertPath, '*')}`]);
+        await adbRootShell([`chcon u:object_r:system_file:s0  ${systemCertPath}`]);
     },
     async removeCertificateAuthority(path) {
         const certFilename = `${await this._internal.getCertificateSubjectHashOld(path)}.0`;


### PR DESCRIPTION
This should not break any existing installations. However, if users used the version with the bug and never removed the certificate, it might still have the wrong permissions (given the tempfs is still active).